### PR TITLE
Implement mixed-mode class activation

### DIFF
--- a/AdvanceDLSupport.sln
+++ b/AdvanceDLSupport.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", ".\docs", "{96E3AE84
 		docs\supported_constructs.md = docs\supported_constructs.md
 		docs\advanced_config.md = docs\advanced_config.md
 		docs\complex_types.md = docs\complex_types.md
+		docs\mixed_mode_classes.md = docs\mixed_mode_classes.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdvancedDLSupport", "AdvancedDLSupport\AdvancedDLSupport.csproj", "{7EDC8F84-DF28-4C3C-AF56-F283B694218A}"

--- a/AdvancedDLSupport.Tests/AdvancedDLSupport.Tests.csproj
+++ b/AdvancedDLSupport.Tests/AdvancedDLSupport.Tests.csproj
@@ -40,11 +40,10 @@
   </PropertyGroup>
   <Target Name="InitCMake" BeforeTargets="CompileTestLibraries" Condition="!Exists('$(CMakeBuildDir)\CMakeCache.txt')">
     <Exec Command="mkdir -p $(CMakeBuildDir)" />
-    <Exec Command="cmake -G $(CMakeGenerator) -DOUTPUT_PATH=$(OutDir) -DPROJECT_PATH=$(MSBuildProjectDirectory) .."
-          WorkingDirectory="$(CMakeBuildDir)" />
+    <Exec Command="cmake -G $(CMakeGenerator) -DOUTPUT_PATH=$(OutDir) -DPROJECT_PATH=$(MSBuildProjectDirectory) .." WorkingDirectory="$(CMakeBuildDir)" />
   </Target>
   <Target Name="CompileTestLibraries" AfterTargets="AfterBuild">
-    <Exec Command="cmake --build . --target install" WorkingDirectory="$(CMakeBuildDir)" Condition="'$(OS)' == 'Unix'"/>
-    <Exec Command="cmake --build . --target INSTALL" WorkingDirectory="$(CMakeBuildDir)" Condition="'$(OS)' == 'Windows_NT'"/>
+    <Exec Command="cmake --build . --target install" WorkingDirectory="$(CMakeBuildDir)" Condition="'$(OS)' == 'Unix'" />
+    <Exec Command="cmake --build . --target INSTALL" WorkingDirectory="$(CMakeBuildDir)" Condition="'$(OS)' == 'Windows_NT'" />
   </Target>
 </Project>

--- a/AdvancedDLSupport.Tests/Data/Classes/MixedModeClass.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/MixedModeClass.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+	public abstract class MixedModeClass : AnonymousImplementationBase, IMixedModeLibrary
+	{
+		public MixedModeClass(string path, Type interfaceType, ImplementationConfiguration configuration, TypeTransformerRepository transformerRepository)
+			: base(path, interfaceType, configuration, transformerRepository)
+		{
+		}
+
+		public bool RanManagedSubtract { get; private set; }
+
+		public bool RanManagedSetter { get; private set; }
+
+		public int ManagedAdd(int a, int b)
+		{
+			return a + b;
+		}
+
+		public int OtherNativeProperty
+		{
+			get => 32;
+
+			set => this.RanManagedSetter = true;
+		}
+
+		public abstract int NativeProperty { get; set; }
+		public abstract int Multiply(int value, int multiplier);
+
+		public int Subtract(int value, int other)
+		{
+			RanManagedSubtract = true;
+			return value - other;
+		}
+	}
+}

--- a/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassThatDoesNotInheritFromAnonymousBase.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassThatDoesNotInheritFromAnonymousBase.cs
@@ -1,0 +1,22 @@
+﻿namespace AdvancedDLSupport.Tests.Data.Classes
+{
+	public abstract class MixedModeClassThatDoesNotInheritFromAnonymousBase : IMixedModeLibrary
+	{
+		public bool RanManagedSubtract { get; private set; }
+
+		public int ManagedAdd(int a, int b)
+		{
+			return a + b;
+		}
+
+		public abstract int NativeProperty { get; set; }
+		public abstract int OtherNativeProperty { get; set; }
+		public abstract int Multiply(int value, int multiplier);
+
+		public int Subtract(int value, int other)
+		{
+			RanManagedSubtract = true;
+			return value - other;
+		}
+	}
+}

--- a/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassThatIsNotAbstract.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassThatIsNotAbstract.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+	public class MixedModeClassThatIsNotAbstract : AnonymousImplementationBase, IMixedModeLibrary
+	{
+		public MixedModeClassThatIsNotAbstract(string path, Type interfaceType, ImplementationConfiguration configuration, TypeTransformerRepository transformerRepository)
+			: base(path, interfaceType, configuration, transformerRepository)
+		{
+		}
+
+		public bool RanManagedSubtract { get; private set; }
+
+		public int ManagedAdd(int a, int b)
+		{
+			return a + b;
+		}
+
+		public int NativeProperty { get; set; }
+		public int OtherNativeProperty { get; set; }
+
+		public int Multiply(int value, int multiplier)
+		{
+			return value * multiplier;
+		}
+
+		public int Subtract(int value, int other)
+		{
+			RanManagedSubtract = true;
+			return value - other;
+		}
+	}
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibrary.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibrary.cs
@@ -1,0 +1,11 @@
+﻿namespace AdvancedDLSupport.Tests.Data
+{
+	public interface IMixedModeLibrary
+	{
+		int NativeProperty { get; set; }
+		int OtherNativeProperty { get; set; }
+
+		int Multiply(int a, int b);
+		int Subtract(int a, int b);
+	}
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using AdvancedDLSupport.Tests.Data;
+using AdvancedDLSupport.Tests.Data.Classes;
+using Xunit;
+
+namespace AdvancedDLSupport.Tests.Integration
+{
+	public class MixedModeTests
+	{
+		private const string LibraryName = "MixedModeTests";
+
+		private readonly MixedModeClass MixedModeClass;
+		private readonly AnonymousImplementationBuilder Builder;
+
+		public MixedModeTests()
+		{
+			this.Builder = new AnonymousImplementationBuilder();
+
+			this.MixedModeClass = this.Builder.ResolvedAndActivateClass<MixedModeClass, IMixedModeLibrary>(LibraryName);
+		}
+
+		[Fact]
+		public void ThrowsIfClassDoesNotInheritFromAnonymousImplementationBase()
+		{
+			Assert.Throws<ArgumentException>
+			(
+				() =>
+					Builder.ResolvedAndActivateClass<MixedModeClassThatDoesNotInheritFromAnonymousBase, IMixedModeLibrary>(LibraryName)
+			);
+		}
+
+		[Fact]
+		public void ThrowsIfClassIsNotAbstract()
+		{
+			Assert.Throws<ArgumentException>
+			(
+				() =>
+					Builder.ResolvedAndActivateClass<MixedModeClassThatIsNotAbstract, IMixedModeLibrary>(LibraryName)
+			);
+		}
+
+		[Fact]
+		public void CanOverrideNativeFunctionWithManagedImplementationOnClass()
+		{
+			var result = this.MixedModeClass.Subtract(10, 5);
+
+			Assert.Equal(5, result);
+			Assert.True(this.MixedModeClass.RanManagedSubtract);
+		}
+
+		[Fact]
+		public void CanCallPurelyManagedFunctionOnClass()
+		{
+			var result = this.MixedModeClass.ManagedAdd(5, 5);
+
+			Assert.Equal(10, result);
+		}
+
+		[Fact]
+		public void CanCallNativeFunctionOnClass()
+		{
+			var result = this.MixedModeClass.Multiply(5, 5);
+
+			Assert.Equal(25, result);
+		}
+
+		[Fact]
+		public void CanUseNativePropertyOnClass()
+		{
+			var originalValue = this.MixedModeClass.NativeProperty;
+			Assert.Equal(0, originalValue);
+
+			var newValue = 16;
+			this.MixedModeClass.NativeProperty = newValue;
+			Assert.Equal(newValue, this.MixedModeClass.NativeProperty);
+		}
+
+		[Fact]
+		public void CanOverrideNativePropertyWithManagedImplementationOnClass()
+		{
+			Assert.Equal(32, this.MixedModeClass.OtherNativeProperty);
+
+			this.MixedModeClass.OtherNativeProperty = 255;
+			Assert.True(this.MixedModeClass.RanManagedSetter);
+		}
+	}
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
@@ -20,16 +20,6 @@ namespace AdvancedDLSupport.Tests.Integration
 		}
 
 		[Fact]
-		public void ThrowsIfClassDoesNotInheritFromAnonymousImplementationBase()
-		{
-			Assert.Throws<ArgumentException>
-			(
-				() =>
-					Builder.ResolvedAndActivateClass<MixedModeClassThatDoesNotInheritFromAnonymousBase, IMixedModeLibrary>(LibraryName)
-			);
-		}
-
-		[Fact]
 		public void ThrowsIfClassIsNotAbstract()
 		{
 			Assert.Throws<ArgumentException>

--- a/AdvancedDLSupport.Tests/c/CMakeLists.txt
+++ b/AdvancedDLSupport.Tests/c/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(LazyLoadingTests SHARED src/LazyLoadingTests.c ${SHARED_HEADERS})
 add_library(PropertyTests SHARED src/PropertyTests.c ${SHARED_HEADERS})
 add_library(RemappingTests SHARED src/RemappingTests.c ${SHARED_HEADERS})
 add_library(ComplexTypeTests SHARED src/ComplexTypeTests.c ${SHARED_HEADERS})
+add_library(MixedModeTests SHARED src/MixedModeTests.c ${SHARED_HEADERS})
 
 get_filename_component(INSTALL_PATH_ABSOLUTE "${PROJECT_PATH}/${OUTPUT_PATH}" ABSOLUTE)
 
@@ -42,5 +43,6 @@ install(TARGETS
             PropertyTests
             RemappingTests
             ComplexTypeTests
+            MixedModeTests
         DESTINATION
             ${INSTALL_PATH_ABSOLUTE})

--- a/AdvancedDLSupport.Tests/c/src/MixedModeTests.c
+++ b/AdvancedDLSupport.Tests/c/src/MixedModeTests.c
@@ -1,0 +1,20 @@
+#include <stdlib.h>
+#include "wincomp.h"
+
+__declspec(dllexport) int32_t NativeProperty = 0;
+__declspec(dllexport) int32_t OtherNativeProperty = 0;
+
+__declspec(dllexport) void SetNativePropertyValue()
+{
+    NativeProperty = 128;
+}
+
+__declspec(dllexport) int32_t Multiply(int value, int multiplier)
+{
+    return value * multiplier;
+}
+
+__declspec(dllexport) int32_t Subtract(int value, int other)
+{
+    return value - other;
+}

--- a/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
+++ b/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
@@ -46,6 +46,13 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
+  <member name="M:AdvancedDLSupport.AnonymousImplementationBuilder.ResolvedAndActivateClass``2(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <parameter name="libraryPath">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
   <member name="M:AdvancedDLSupport.Extensions.MethodInfoExtensions.HasComplexParameters(System.Reflection.MethodBase)">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />

--- a/AdvancedDLSupport/AnonymousImplementationBuilder.cs
+++ b/AdvancedDLSupport/AnonymousImplementationBuilder.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.InteropServices.ComTypes;
 using AdvancedDLSupport.Extensions;
 using AdvancedDLSupport.ImplementationGenerators;
 using JetBrains.Annotations;
@@ -68,6 +69,76 @@ namespace AdvancedDLSupport
         }
 
         /// <summary>
+        /// Attempts to resolve a mixed-mode class, implementing a C function interface.
+        /// </summary>
+        /// <param name="libraryPath">The path to the native library to bind to.</param>
+        /// <typeparam name="TClass">The base class for the implementation to generate.</typeparam>
+        /// <typeparam name="TInterface">The interface to implement.</typeparam>
+        /// <returns>An instance of the class.</returns>
+        /// <exception cref="ArgumentException">Thrown if either of the type arguments are incompatible.</exception>
+        [NotNull, PublicAPI]
+        public TClass ResolvedAndActivateClass<TClass, TInterface>([NotNull] string libraryPath)
+            where TClass : class
+            where TInterface : class
+        {
+            var classType = typeof(TClass);
+            if (!classType.IsAbstract)
+            {
+                throw new ArgumentException("The class to active must be abstract.", nameof(TClass));
+            }
+
+            if (!classType.IsSubclassOf(typeof(AnonymousImplementationBase)) && classType != typeof(AnonymousImplementationBase))
+            {
+                throw new ArgumentException($"The class to activate must inherit from {nameof(AnonymousImplementationBase)}.", nameof(TClass));
+            }
+
+            var interfaceType = typeof(TInterface);
+            if (!interfaceType.IsInterface)
+            {
+                throw new ArgumentException("The interface to activate on the class must be an interface type.", nameof(TInterface));
+            }
+
+            var resolveResult = DynamicLinkLibraryPathResolver.ResolveAbsolutePath(libraryPath, true);
+            if (!resolveResult.IsSuccess)
+            {
+                var executingDir = Directory.GetParent(Assembly.GetExecutingAssembly().Location).FullName;
+                var filesInDir = string.Join(", ", Directory.EnumerateFiles(executingDir));
+                throw new FileNotFoundException($"The specified library (\"{libraryPath}\") was not found in any of the loader search paths. Executing dir was {executingDir}, files were {filesInDir}", libraryPath, resolveResult.Exception);
+            }
+
+            libraryPath = resolveResult.Path;
+
+            var key = new LibraryIdentifier(interfaceType, libraryPath, Configuration);
+            if (TypeCache.TryGetValue(key, out var cachedType))
+            {
+                if (!(cachedType is null))
+                {
+                    var anonymousInstance = CreateAnonymousImplementationInstance<TInterface>(cachedType, libraryPath, Configuration, TransformerRepository);
+
+                    return anonymousInstance as TClass ?? throw new InvalidOperationException("The resulting instance was not convertible to an instance of the class.");
+                }
+            }
+
+            lock (BuilderLock)
+            {
+                try
+                {
+                    var finalType = GenerateInterfaceImplementationType(classType, interfaceType);
+
+                    var anonymousInstance = CreateAnonymousImplementationInstance<TInterface>(finalType, libraryPath, Configuration, TransformerRepository);
+                    TypeCache.TryAdd(key, finalType);
+
+                    return anonymousInstance as TClass ?? throw new InvalidOperationException("The resulting instance was not convertible to an instance of the class.");
+                }
+                catch (TargetInvocationException tex)
+                {
+                    // Unwrap target invocation exceptions, since we can fail in the constructor
+                    throw tex.InnerException ?? tex;
+                }
+            }
+        }
+
+        /// <summary>
         /// Attempts to resolve interface to C Library via C# Interface by dynamically creating C# Class during runtime
         /// and return a new instance of the said class. This approach does not resolve any C++ implication such as name manglings.
         /// </summary>
@@ -88,95 +159,86 @@ namespace AdvancedDLSupport
                 libraryPath = new DllMapResolver().MapLibraryName(interfaceType, libraryPath);
             }
 
-            var resolveResult = DynamicLinkLibraryPathResolver.ResolveAbsolutePath(libraryPath, true);
-            if (!resolveResult.IsSuccess)
+            var anonymousInstance = ResolvedAndActivateClass<AnonymousImplementationBase, T>(libraryPath);
+            return anonymousInstance as T ?? throw new InvalidOperationException("The resulting instance was not convertible to an instance of the interface.");
+        }
+
+        private Type GenerateInterfaceImplementationType(Type baseClassType, Type interfaceType)
+        {
+            if (!baseClassType.IsSubclassOf(typeof(AnonymousImplementationBase)) && baseClassType != typeof(AnonymousImplementationBase))
             {
-                var executingDir = Directory.GetParent(Assembly.GetExecutingAssembly().Location).FullName;
-                var filesInDir = string.Join(", ", Directory.EnumerateFiles(executingDir));
-                throw new FileNotFoundException($"The specified library (\"{libraryPath}\") was not found in any of the loader search paths. Executing dir was {executingDir}, files were {filesInDir}", libraryPath, resolveResult.Exception);
-            }
-
-            libraryPath = resolveResult.Path;
-
-            var key = new LibraryIdentifier(interfaceType, libraryPath, Configuration);
-            if (TypeCache.TryGetValue(key, out var cachedType))
-            {
-                if (!(cachedType is null))
-                {
-                    return CreateInterfaceInstance<T>(cachedType, libraryPath, Configuration, TransformerRepository);
-                }
-            }
-
-            lock (BuilderLock)
-            {
-                // Let's determine a name for our class!
-                var typeName = interfaceType.Name.StartsWith("I") ? interfaceType.Name.Substring(1) : $"Generated_{interfaceType.Name}";
-
-                if (typeName.IsNullOrWhiteSpace())
-                {
-                    typeName = $"Generated_{interfaceType.Name}";
-                }
-
-                var uniqueIdentifier = Guid.NewGuid().ToString().Replace("-", "_");
-                typeName = $"{typeName}_{uniqueIdentifier}";
-
-                // Create a new type for the anonymous implementation
-                var typeBuilder = ModuleBuilder.DefineType
+                throw new ArgumentException
                 (
-                    typeName,
-                    TypeAttributes.AutoClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed,
-                    typeof(AnonymousImplementationBase),
-                    new[] { interfaceType }
+                    $"The base class of the implementation type must be either {nameof(AnonymousImplementationBase)} or a subclass thereof.",
+                    nameof(baseClassType)
                 );
+            }
 
-                // Now the constructor
-                var anonymousConstructor = typeof(AnonymousImplementationBase)
+            var typeName = GenerateTypeName(interfaceType);
+
+            // Create a new type for the anonymous implementation
+            var typeBuilder = ModuleBuilder.DefineType
+            (
+                typeName,
+                TypeAttributes.AutoClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed,
+                baseClassType,
+                new[] { interfaceType }
+            );
+
+            // Now the constructor
+            var anonymousConstructor = typeof(AnonymousImplementationBase)
                 .GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
                 .First
                 (
                     c => c.GetCustomAttribute<AnonymousConstructorAttribute>() != null
                 );
 
-                var constructorBuilder = typeBuilder.DefineConstructor
-                (
-                    MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig,
-                    CallingConventions.Standard,
-                    anonymousConstructor.GetParameters().Select(p => p.ParameterType).ToArray()
-                );
+            var constructorBuilder = typeBuilder.DefineConstructor
+            (
+                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig,
+                CallingConventions.Standard,
+                anonymousConstructor.GetParameters().Select(p => p.ParameterType).ToArray()
+            );
 
-                constructorBuilder.DefineParameter(1, ParameterAttributes.In, "libraryPath");
-                var ctorIL = constructorBuilder.GetILGenerator();
-                for (int i = 0; i <= anonymousConstructor.GetParameters().Length; ++i)
-                {
-                    ctorIL.Emit(OpCodes.Ldarg, i);
-                }
-
-                ctorIL.Emit(OpCodes.Call, anonymousConstructor);
-
-                ConstructMethods(typeBuilder, ctorIL, interfaceType);
-                ConstructProperties(typeBuilder, ctorIL, interfaceType);
-
-                ctorIL.Emit(OpCodes.Ret);
-
-                try
-                {
-                    var finalType = typeBuilder.CreateTypeInfo();
-
-                    var instance = CreateInterfaceInstance<T>(finalType, libraryPath, Configuration, TransformerRepository);
-                    TypeCache.TryAdd(key, finalType);
-
-                    return instance;
-                }
-                catch (TargetInvocationException tex)
-                {
-                    // Unwrap target invocation exceptions, since we can fail in the constructor
-                    throw tex.InnerException ?? tex;
-                }
+            constructorBuilder.DefineParameter(1, ParameterAttributes.In, "libraryPath");
+            var ctorIL = constructorBuilder.GetILGenerator();
+            for (int i = 0; i <= anonymousConstructor.GetParameters().Length; ++i)
+            {
+                ctorIL.Emit(OpCodes.Ldarg, i);
             }
+
+            ctorIL.Emit(OpCodes.Call, anonymousConstructor);
+
+            ConstructMethods(typeBuilder, baseClassType, ctorIL, interfaceType);
+            ConstructProperties(typeBuilder, baseClassType, ctorIL, interfaceType);
+
+            ctorIL.Emit(OpCodes.Ret);
+            return typeBuilder.CreateTypeInfo();
         }
 
         /// <summary>
-        /// Creates an instance of the final interface type.
+        /// Generates a type name for an anonymous type.
+        /// </summary>
+        /// <param name="type">The type to generate the name for.</param>
+        /// <returns>The name.</returns>
+        private static string GenerateTypeName(Type type)
+        {
+            var typeName = type.Name.StartsWith("I")
+                ? type.Name.Substring(1)
+                : $"Generated_{type.Name}";
+
+            if (typeName.IsNullOrWhiteSpace())
+            {
+                typeName = $"Generated_{type.Name}";
+            }
+
+            var uniqueIdentifier = Guid.NewGuid().ToString().Replace("-", "_");
+            typeName = $"{typeName}_{uniqueIdentifier}";
+            return typeName;
+        }
+
+        /// <summary>
+        /// Creates an instance of the final implementation type.
         /// </summary>
         /// <param name="anonymousType">The constructed anonymous type.</param>
         /// <param name="library">The path to or name of the library</param>
@@ -184,7 +246,7 @@ namespace AdvancedDLSupport
         /// <param name="transformerRepository">The type transformer repository.</param>
         /// <typeparam name="T">The interface type.</typeparam>
         /// <returns>An instance of the anonymous type implementing <typeparamref name="T"/>.</returns>
-        private T CreateInterfaceInstance<T>
+        private T CreateAnonymousImplementationInstance<T>
         (
             [NotNull] Type anonymousType,
             [NotNull] string library,
@@ -199,9 +261,16 @@ namespace AdvancedDLSupport
         /// Constructs the implementations for all normal methods.
         /// </summary>
         /// <param name="typeBuilder">Reference to TypeBuilder to define the methods in.</param>
+        /// <param name="baseClassType">The type of the base class.</param>
         /// <param name="ctorIL">Constructor IL emitter to initialize methods by assigning symbol pointer to delegate.</param>
         /// <param name="interfaceType">Type definition of a provided interface.</param>
-        private void ConstructMethods([NotNull] TypeBuilder typeBuilder, [NotNull] ILGenerator ctorIL, [NotNull] Type interfaceType)
+        private void ConstructMethods
+        (
+            [NotNull] TypeBuilder typeBuilder,
+            Type baseClassType,
+            [NotNull] ILGenerator ctorIL,
+            [NotNull] Type interfaceType
+        )
         {
             var methodGenerator = new MethodImplementationGenerator(ModuleBuilder, typeBuilder, ctorIL, Configuration);
             var complexMethodGenerator = new ComplexMethodImplementationGenerator(ModuleBuilder, typeBuilder, ctorIL, Configuration, TransformerRepository);
@@ -209,19 +278,33 @@ namespace AdvancedDLSupport
             // Let's define our methods!
             foreach (var method in interfaceType.GetMethods())
             {
+                var targetMethod = method;
+
                 // Skip any property accessor methods
                 if (method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_")))
                 {
                     continue;
                 }
 
+                // Skip methods with a managed implementation in the base class
+                var baseClassMethod = baseClassType.GetMethod(method.Name, method.GetParameters().Select(p => p.ParameterType).ToArray());
+                if (!(baseClassMethod is null))
+                {
+                    if (!baseClassMethod.IsAbstract)
+                    {
+                        continue;
+                    }
+
+                    targetMethod = baseClassMethod;
+                }
+
                 if (method.IsComplexMethod())
                 {
-                    complexMethodGenerator.GenerateImplementation(method);
+                    complexMethodGenerator.GenerateImplementation(targetMethod);
                 }
                 else
                 {
-                    methodGenerator.GenerateImplementation(method);
+                    methodGenerator.GenerateImplementation(targetMethod);
                 }
             }
         }
@@ -230,15 +313,47 @@ namespace AdvancedDLSupport
         /// Constructs the implementations for all properties.
         /// </summary>
         /// <param name="typeBuilder">Reference to TypeBuilder to define the methods in.</param>
+        /// <param name="baseClassType">The type of the base class.</param>
         /// <param name="ctorIL">Constructor IL emitter to initialize methods by assigning symbol pointer to delegate.</param>
         /// <param name="interfaceType">Type definition of a provided interface.</param>
-        private void ConstructProperties([NotNull] TypeBuilder typeBuilder, [NotNull] ILGenerator ctorIL, [NotNull] Type interfaceType)
+        private void ConstructProperties
+        (
+            [NotNull] TypeBuilder typeBuilder,
+            Type baseClassType,
+            [NotNull] ILGenerator ctorIL,
+            [NotNull] Type interfaceType
+        )
         {
             var propertyGenerator = new PropertyImplementationGenerator(ModuleBuilder, typeBuilder, ctorIL, Configuration);
 
             foreach (var property in interfaceType.GetProperties())
             {
-                propertyGenerator.GenerateImplementation(property);
+                var targetProperty = property;
+
+                // Skip properties with a managed implementation
+                var baseClassProperty = baseClassType.GetProperty(property.Name, property.PropertyType);
+                if (!(baseClassProperty is null))
+                {
+                    var isFullyManaged = !baseClassProperty.GetGetMethod().IsAbstract &&
+                                         !baseClassProperty.GetSetMethod().IsAbstract;
+
+                    if (isFullyManaged)
+                    {
+                        continue;
+                    }
+
+                    var isPartiallyAbstract = baseClassProperty.GetGetMethod().IsAbstract ^
+                                              baseClassProperty.GetSetMethod().IsAbstract;
+
+                    if (isPartiallyAbstract)
+                    {
+                        throw new InvalidOperationException("Properties with overriding managed implementations may not be partially managed.");
+                    }
+
+                    targetProperty = baseClassProperty;
+                }
+
+                propertyGenerator.GenerateImplementation(targetProperty);
             }
         }
     }

--- a/AdvancedDLSupport/AnonymousImplementationBuilder.cs
+++ b/AdvancedDLSupport/AnonymousImplementationBuilder.cs
@@ -78,18 +78,13 @@ namespace AdvancedDLSupport
         /// <exception cref="ArgumentException">Thrown if either of the type arguments are incompatible.</exception>
         [NotNull, PublicAPI]
         public TClass ResolvedAndActivateClass<TClass, TInterface>([NotNull] string libraryPath)
-            where TClass : class
+            where TClass : AnonymousImplementationBase
             where TInterface : class
         {
             var classType = typeof(TClass);
             if (!classType.IsAbstract)
             {
                 throw new ArgumentException("The class to active must be abstract.", nameof(TClass));
-            }
-
-            if (!classType.IsSubclassOf(typeof(AnonymousImplementationBase)) && classType != typeof(AnonymousImplementationBase))
-            {
-                throw new ArgumentException($"The class to activate must inherit from {nameof(AnonymousImplementationBase)}.", nameof(TClass));
             }
 
             var interfaceType = typeof(TInterface);

--- a/AdvancedDLSupport/ImplementationGenerators/ComplexMethodImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/ComplexMethodImplementationGenerator.cs
@@ -68,7 +68,9 @@ namespace AdvancedDLSupport.ImplementationGenerators
             }
 
             GenerateDelegateInvokerBody(loweredMethod.LoweredMethod, loweredMethod.ParameterTypes, delegateBuilderType, delegateField);
-            GenerateComplexMethodBody(method, loweredMethod.LoweredMethod, loweredMethod.ParameterTypes);
+            var implementation = GenerateComplexMethodBody(method, loweredMethod.LoweredMethod, loweredMethod.ParameterTypes);
+
+            this.TargetType.DefineMethodOverride(implementation, method);
 
             AugmentHostingTypeConstructor(symbolName, delegateBuilderType, delegateField);
         }
@@ -80,7 +82,8 @@ namespace AdvancedDLSupport.ImplementationGenerators
         /// <param name="complexInterfaceMethod">The complex method definition.</param>
         /// <param name="loweredMethod">The lowered method definition.</param>
         /// <param name="loweredMethodParameterTypes">The parameter types of the lowered method definition.</param>
-        private void GenerateComplexMethodBody
+        /// <returns>The generated invoker.</returns>
+        private MethodInfo GenerateComplexMethodBody
         (
             [NotNull] MethodInfo complexInterfaceMethod,
             [NotNull] MethodInfo loweredMethod,
@@ -132,6 +135,8 @@ namespace AdvancedDLSupport.ImplementationGenerators
             }
 
             il.Emit(OpCodes.Ret);
+
+            return methodBuilder;
         }
 
         /// <summary>

--- a/AdvancedDLSupport/ImplementationGenerators/MethodImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/MethodImplementationGenerator.cs
@@ -53,7 +53,8 @@ namespace AdvancedDLSupport.ImplementationGenerators
                 delegateField = TargetType.DefineField($"{uniqueMemberIdentifier}_dtm", delegateBuilderType, FieldAttributes.Public);
             }
 
-            GenerateDelegateInvoker(method, delegateBuilderType, delegateField);
+            var implementation = GenerateDelegateInvoker(method, delegateBuilderType, delegateField);
+            this.TargetType.DefineMethodOverride(implementation, method);
 
             AugmentHostingTypeConstructor(symbolName, delegateBuilderType, delegateField);
         }
@@ -100,14 +101,15 @@ namespace AdvancedDLSupport.ImplementationGenerators
         /// <param name="method">The method to invoke.</param>
         /// <param name="delegateBuilderType">The type of the method delegate.</param>
         /// <param name="delegateField">The delegate field.</param>
-        protected void GenerateDelegateInvoker
+        /// <returns>The generated invoker.</returns>
+        protected MethodInfo GenerateDelegateInvoker
         (
             [NotNull] MethodInfo method,
             [NotNull] Type delegateBuilderType,
             [NotNull] FieldInfo delegateField
         )
         {
-            GenerateDelegateInvoker
+            return GenerateDelegateInvoker
             (
                 method.Name,
                 method.ReturnType,
@@ -125,7 +127,8 @@ namespace AdvancedDLSupport.ImplementationGenerators
         /// <param name="parameterTypes">The parameter types of the method.</param>
         /// <param name="delegateBuilderType">The type of the method delegate.</param>
         /// <param name="delegateField">The delegate field.</param>
-        protected void GenerateDelegateInvoker
+        /// <returns>The generated invoker.</returns>
+        protected MethodInfo GenerateDelegateInvoker
         (
             [NotNull] string methodName,
             [NotNull] Type returnType,
@@ -144,6 +147,8 @@ namespace AdvancedDLSupport.ImplementationGenerators
             );
 
             GenerateDelegateInvokerBody(methodBuilder, parameterTypes, delegateBuilderType, delegateField);
+
+            return methodBuilder;
         }
 
         /// <summary>

--- a/AdvancedDLSupport/ImplementationGenerators/PropertyImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/PropertyImplementationGenerator.cs
@@ -101,7 +101,7 @@ namespace AdvancedDLSupport.ImplementationGenerators
             TargetTypeConstructorIL.Emit(OpCodes.Stfld, propertyFieldBuilder);
         }
 
-        private void GeneratePropertySetter
+        private MethodBuilder GeneratePropertySetter
         (
             [NotNull] PropertyInfo property,
             [NotNull] FieldInfo propertyFieldBuilder,
@@ -188,9 +188,12 @@ namespace AdvancedDLSupport.ImplementationGenerators
             setterIL.Emit(OpCodes.Ret);
 
             propertyBuilder.SetSetMethod(setterMethod);
+            this.TargetType.DefineMethodOverride(setterMethod, actualSetMethod);
+
+            return setterMethod;
         }
 
-        private void GeneratePropertyGetter
+        private MethodBuilder GeneratePropertyGetter
         (
             [NotNull] PropertyInfo property,
             [NotNull] FieldInfo propertyFieldBuilder,
@@ -258,6 +261,9 @@ namespace AdvancedDLSupport.ImplementationGenerators
             getterIL.Emit(OpCodes.Ret);
 
             propertyBuilder.SetGetMethod(getterMethod);
+            this.TargetType.DefineMethodOverride(getterMethod, actualGetMethod);
+
+            return getterMethod;
         }
     }
 }

--- a/AdvancedDLSupport/Utility/GeneratedImplementationTypeIdentifier.cs
+++ b/AdvancedDLSupport/Utility/GeneratedImplementationTypeIdentifier.cs
@@ -7,20 +7,27 @@ namespace AdvancedDLSupport
     /// <summary>
     /// A key struct for ConcurrentDictionary TypeCache for all generated types provided by DLSupportConstructor.
     /// </summary>
-    internal struct LibraryIdentifier : IEquatable<LibraryIdentifier>
+    internal struct GeneratedImplementationTypeIdentifier : IEquatable<GeneratedImplementationTypeIdentifier>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="LibraryIdentifier"/> struct.
+        /// Initializes a new instance of the <see cref="GeneratedImplementationTypeIdentifier"/> struct.
         /// </summary>
+        /// <param name="baseClassType">The base class of the library.</param>
         /// <param name="interfaceType">The interface type.</param>
         /// <param name="libraryPath">The path to the library. Will be resolved to an absolute path.</param>
         /// <param name="configuration">The configuration used for the library.</param>
-        public LibraryIdentifier([NotNull] Type interfaceType, [NotNull] string libraryPath, ImplementationConfiguration configuration)
+        public GeneratedImplementationTypeIdentifier([NotNull] Type baseClassType, [NotNull] Type interfaceType, [NotNull] string libraryPath, ImplementationConfiguration configuration)
         {
+            _baseClassType = baseClassType;
             _interfaceType = interfaceType;
             _configuration = configuration;
             _absoluteLibraryPath = Path.GetFullPath(libraryPath);
         }
+
+        /// <summary>
+        /// The base class type of the library.
+        /// </summary>
+        private readonly Type _baseClassType;
 
         /// <summary>
         /// The interface type for the library.
@@ -44,11 +51,13 @@ namespace AdvancedDLSupport
         public Type GetInterfaceType() => _interfaceType;
 
         /// <inheritdoc />
-        public bool Equals(LibraryIdentifier other)
+        public bool Equals(GeneratedImplementationTypeIdentifier other)
         {
-            return _interfaceType == other._interfaceType &&
-                   string.Equals(_absoluteLibraryPath, other._absoluteLibraryPath) &&
-                   _configuration.Equals(other._configuration);
+            return
+                _baseClassType == other._baseClassType &&
+                _interfaceType == other._interfaceType &&
+                string.Equals(_absoluteLibraryPath, other._absoluteLibraryPath) &&
+                _configuration.Equals(other._configuration);
         }
 
         /// <inheritdoc />
@@ -59,7 +68,7 @@ namespace AdvancedDLSupport
                 return false;
             }
 
-            return obj is LibraryIdentifier identifier && Equals(identifier);
+            return obj is GeneratedImplementationTypeIdentifier identifier && Equals(identifier);
         }
 
         /// <inheritdoc />
@@ -68,9 +77,10 @@ namespace AdvancedDLSupport
             unchecked
             {
                 return
-                ((_interfaceType != null ? _interfaceType.GetHashCode() : 0) * 397) ^
-                (_absoluteLibraryPath != null ? _absoluteLibraryPath.GetHashCode() : 0) ^
-                (_configuration.GetHashCode() * 397);
+                    ((_baseClassType != null ? _interfaceType.GetHashCode() : 0) * 397) ^
+                    (_interfaceType != null ? _interfaceType.GetHashCode() : 0) * 397 ^
+                    (_absoluteLibraryPath != null ? _absoluteLibraryPath.GetHashCode() : 0) ^
+                    (_configuration.GetHashCode() * 397);
             }
         }
     }

--- a/AdvancedDLSupport/Utility/LibraryIdentifierEqualityComparer.cs
+++ b/AdvancedDLSupport/Utility/LibraryIdentifierEqualityComparer.cs
@@ -5,16 +5,16 @@ namespace AdvancedDLSupport
     /// <summary>
     /// Compares library identifiers for equality.
     /// </summary>
-    internal class LibraryIdentifierEqualityComparer : IEqualityComparer<LibraryIdentifier>
+    internal class LibraryIdentifierEqualityComparer : IEqualityComparer<GeneratedImplementationTypeIdentifier>
     {
         /// <inheritdoc />
-        public bool Equals(LibraryIdentifier x, LibraryIdentifier y)
+        public bool Equals(GeneratedImplementationTypeIdentifier x, GeneratedImplementationTypeIdentifier y)
         {
             return x.Equals(y);
         }
 
         /// <inheritdoc />
-        public int GetHashCode(LibraryIdentifier obj)
+        public int GetHashCode(GeneratedImplementationTypeIdentifier obj)
         {
             return obj.GetHashCode();
         }

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,4 +4,5 @@ below.
 1. [Quickstart](quickstart.md)
 2. [Supported Constructs](supported_constructs.md)
 3. [Advanced Configuration](advanced_config.md)
-3. [Complex Types](complex_types.md)
+4. [Complex Types](complex_types.md)
+5. [Mixed-Mode Classes](mixed_mode_classes.md)

--- a/docs/mixed_mode_classes.md
+++ b/docs/mixed_mode_classes.md
@@ -1,0 +1,88 @@
+Mixed-Mode Classes
+==========
+
+Mixed-mode classes are useful constructs for object-oriented C programming, as well as 
+instances where you may want to have native and managed code coexisting in the same
+class definition.
+
+In short, it allows you to define normal classes that implement native interfaces, 
+and activate instances of them like you'd do with normal native interfaces.
+
+As an example, take this class (taken from the unit test suite):
+
+```cs
+using System;
+
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+	public abstract class MixedModeClass : AnonymousImplementationBase, IMixedModeLibrary
+	{
+		public MixedModeClass(string path, Type interfaceType, ImplementationConfiguration configuration, TypeTransformerRepository transformerRepository)
+			: base(path, interfaceType, configuration, transformerRepository)
+		{
+		}
+
+		public bool RanManagedSubtract { get; private set; }
+
+		public bool RanManagedSetter { get; private set; }
+
+		public int ManagedAdd(int a, int b)
+		{
+			return a + b;
+		}
+
+		public int OtherNativeProperty
+		{
+			get => 32;
+
+			set => this.RanManagedSetter = true;
+		}
+
+		public abstract int NativeProperty { get; set; }
+
+		public abstract int Multiply(int value, int multiplier);
+
+		public int Subtract(int value, int other) 
+		{
+			RanManagedSubtract = true;
+			return value - other;
+		}
+	}
+}
+```
+
+with the corresponding interface
+
+```cs
+namespace AdvancedDLSupport.Tests.Data
+{
+	public interface IMixedModeLibrary
+	{
+		int NativeProperty { get; set; }
+		int OtherNativeProperty { get; set; }
+
+		int Multiply(int a, int b);
+		int Subtract(int a, int b);
+	}
+}
+```
+
+As you can see, managed functions can coexist with unmanaged ones, and managed code can override 
+implementations of the unmanaged functions (as seen in Subtract and OtherNativeProperty).
+
+In order to create a mixed-mode class, simply declare an `abstract` class that inherits from `AnonymousImplementationBase`, 
+and implements the interface you want to activate. Any interface members can have explicit managed
+implementations, or remain `abstract` to be routed to their corresponding native implementations.
+
+There are a few limitations:
+
+* Mixed-mode class must inherit from AnonymousImplementationBase
+* Mixed-mode classes must be abstract
+* Properties may only be fully managed or fully unmanaged - no mixing of getters and setters
+
+Once you have your class definition, instances of it can be created in much the same way as you
+would interface instances:
+
+```cs
+AnonymousImplementationBuilder::ResolvedAndActivateClass<MixedModeClass, IMixedModeLibrary>(LibraryName);
+```


### PR DESCRIPTION
This PR implements a new feature for the library - mixed-mode class activation.

Mixed-mode class activation allows end users to define full classes that implement a native interface, which are then activated and injected in much the same way a simple interface would.

However, mixed-mode classes allows seamless intermingling of managed and unmanaged code, and allows managed overrides of the managed interface functions. As an example, this is the test class used for the implementation:

```cs
using System;

namespace AdvancedDLSupport.Tests.Data.Classes
{
	public abstract class MixedModeClass : AnonymousImplementationBase, IMixedModeLibrary
	{
		public MixedModeClass(string path, Type interfaceType, ImplementationConfiguration configuration, TypeTransformerRepository transformerRepository)
			: base(path, interfaceType, configuration, transformerRepository)
		{
		}

		public bool RanManagedSubtract { get; private set; }

		public bool RanManagedSetter { get; private set; }

		public int ManagedAdd(int a, int b)
		{
			return a + b;
		}

		// Belongs to the native library
		public int OtherNativeProperty
		{
			get => 32;

			set => this.RanManagedSetter = true;
		}

		// Belongs to the native library
		public abstract int NativeProperty { get; set; }

		// Belongs to the native library
		public abstract int Multiply(int value, int multiplier);

		// Belongs to the native library
		public int Subtract(int value, int other) 
		{
			RanManagedSubtract = true;
			return value - other;
		}
	}
}
```

As you can see, managed functions can coexist with unmanaged ones, and managed code can override implementations of the unmanaged functions (as seen in `Subtract` and `OtherNativeProperty`).

There are a few limitations:

- Mixed-mode class must inherit from AnonymousImplementationBase
- Mixed-mode classes must be abstract
- Properties may only be fully managed or fully unmanaged - no mixing of getters and setters

Activation of mixed-mode classes follows a similar pattern to simple interface activation:
```cs
this.MixedModeClass = this.Builder.ResolvedAndActivateClass<MixedModeClass, IMixedModeLibrary>(LibraryName);
```