### PR TITLE
Use the correct way of finding the system directory

### DIFF
--- a/AdvancedDLSupport/PathResolvers/WindowsPathResolver.cs
+++ b/AdvancedDLSupport/PathResolvers/WindowsPathResolver.cs
@@ -48,7 +48,6 @@ namespace AdvancedDLSupport
             }
 
             var windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-
             var sys16Dir = Path.Combine(windowsDir, "System");
             libraryLocation = Path.GetFullPath(Path.Combine(sys16Dir, library));
             if (File.Exists(libraryLocation))

--- a/AdvancedDLSupport/PathResolvers/WindowsPathResolver.cs
+++ b/AdvancedDLSupport/PathResolvers/WindowsPathResolver.cs
@@ -40,14 +40,14 @@ namespace AdvancedDLSupport
                 return ResolvePathResult.FromSuccess(libraryLocation);
             }
 
-            var windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
-
-            var sys32Dir = Path.Combine(windowsDir, "System32");
-            libraryLocation = Path.GetFullPath(Path.Combine(sys32Dir, library));
+            var sysDir = Environment.SystemDirectory;
+            libraryLocation = Path.GetFullPath(Path.Combine(sysDir, library));
             if (File.Exists(libraryLocation))
             {
                 return ResolvePathResult.FromSuccess(libraryLocation);
             }
+
+            var windowsDir = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
 
             var sys16Dir = Path.Combine(windowsDir, "System");
             libraryLocation = Path.GetFullPath(Path.Combine(sys16Dir, library));


### PR DESCRIPTION
### Purpose of this PR

* Uses the correct API for finding out the System32 directory instead of Path.Combine
* Affects the Windows Path Resolver

### Testing status

* The path resolving logic has been manually tested in an interactive C# prompt.
