### PR TITLE
Implement optional suppression of unmanaged code security

### DIFF
--- a/AdvancedDLSupport.Benchmark/AdvancedDLSupport.Benchmark.ExternalAnnotations.xml
+++ b/AdvancedDLSupport.Benchmark/AdvancedDLSupport.Benchmark.ExternalAnnotations.xml
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly name="AdvancedDLSupport.Benchmark">
+  <member name="T:AdvancedDLSupport.Benchmark.Benchmarks.InteropMethodsByRef">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor" />
+  </member>
+  <member name="T:AdvancedDLSupport.Benchmark.Benchmarks.InteropMethodsByValue">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor" />
+  </member>
   <member name="T:AdvancedDLSupport.Benchmark.Data.Matrix2">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>

--- a/AdvancedDLSupport.Benchmark/Benchmarks/BenchmarkBase.cs
+++ b/AdvancedDLSupport.Benchmark/Benchmarks/BenchmarkBase.cs
@@ -63,7 +63,7 @@ namespace AdvancedDLSupport.Benchmark.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            ADLLibrary = NativeLibraryBuilder.Default.ActivateInterface<ITest>(Program.LibraryName);
+            ADLLibrary = new NativeLibraryBuilder(GenerateDisposalChecks).ActivateInterface<ITest>(Program.LibraryName);
             ADLLibraryWithoutDisposeChecks = new NativeLibraryBuilder().ActivateInterface<ITest>(Program.LibraryName);
             ADLLibraryWithSuppressedSecurity = new NativeLibraryBuilder(SuppressSecurity).ActivateInterface<ITest>(Program.LibraryName);
             ADLLibraryWithCalli = new NativeLibraryBuilder(UseIndirectCalls).ActivateInterface<ITest>(Program.LibraryName);

--- a/AdvancedDLSupport.Benchmark/Benchmarks/BenchmarkBase.cs
+++ b/AdvancedDLSupport.Benchmark/Benchmarks/BenchmarkBase.cs
@@ -1,0 +1,122 @@
+﻿//
+//  BenchmarkBase.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using AdvancedDLSupport.Benchmark.Data;
+using AdvancedDLSupport.Benchmark.Native;
+using BenchmarkDotNet.Attributes;
+using static AdvancedDLSupport.ImplementationOptions;
+
+namespace AdvancedDLSupport.Benchmark.Benchmarks
+{
+    /// <summary>
+    /// Acts as the base for library benchmarks.
+    /// </summary>
+    public abstract class BenchmarkBase
+    {
+        /// <summary>
+        /// Gets a source matrix that can be inverted.
+        /// </summary>
+        protected static readonly Matrix2 Source = new Matrix2 { Row0 = { X = 4, Y = 7 }, Row1 = { X = 2, Y = 6 } };
+
+        /// <summary>
+        /// Gets a delegate-based implementation.
+        /// </summary>
+        protected static ITest ADLLibrary { get; private set; }
+
+        /// <summary>
+        /// Gets a delegate-based implementation without disposal checks.
+        /// </summary>
+        protected static ITest ADLLibraryWithoutDisposeChecks { get; private set; }
+
+        /// <summary>
+        /// Gets a delegate-based implementation with suppressed unmanaged code security.
+        /// </summary>
+        protected static ITest ADLLibraryWithSuppressedSecurity { get; private set; }
+
+        /// <summary>
+        /// Gets a calli-based implementation.
+        /// </summary>
+        protected static ITest ADLLibraryWithCalli { get; private set; }
+
+        /// <summary>
+        /// Initializes the local data neccesary to run tests.
+        /// </summary>
+        [GlobalSetup]
+        public void Setup()
+        {
+            ADLLibrary = NativeLibraryBuilder.Default.ActivateInterface<ITest>(Program.LibraryName);
+            ADLLibraryWithoutDisposeChecks = new NativeLibraryBuilder().ActivateInterface<ITest>(Program.LibraryName);
+            ADLLibraryWithSuppressedSecurity = new NativeLibraryBuilder(SuppressSecurity).ActivateInterface<ITest>(Program.LibraryName);
+            ADLLibraryWithCalli = new NativeLibraryBuilder(UseIndirectCalls).ActivateInterface<ITest>(Program.LibraryName);
+        }
+
+        /// <summary>
+        /// Benchmarks a matrix inversion using traditional <see cref="DllImportAttribute"/>s.
+        /// </summary>
+        /// <returns>An inverted matrix.</returns>
+        [Benchmark]
+        public abstract Matrix2 DllImport();
+
+        /// <summary>
+        /// Benchmarks a matrix inversion using traditional <see cref="DllImportAttribute"/>s with suppressed unmanaged
+        /// code security.
+        /// </summary>
+        /// <returns>An inverted matrix.</returns>
+        [Benchmark]
+        public abstract Matrix2 DllImportSuppressedSecurity();
+
+        /// <summary>
+        /// Benchmarks a matrix inversion using <see cref="MulticastDelegate"/>s.
+        /// </summary>
+        /// <returns>An inverted matrix.</returns>
+        [Benchmark]
+        public abstract Matrix2 Delegates();
+
+        /// <summary>
+        /// Benchmarks a matrix inversion using <see cref="MulticastDelegate"/>s, omitting disposal checks.
+        /// </summary>
+        /// <returns>An inverted matrix.</returns>
+        [Benchmark]
+        public abstract Matrix2 DelegatesNoDispose();
+
+        /// <summary>
+        /// Benchmarks a matrix inversion using <see cref="MulticastDelegate"/>s, suppressing unmanaged code security.
+        /// </summary>
+        /// <returns>An inverted matrix.</returns>
+        [Benchmark]
+        public abstract Matrix2 DelegatesSuppressedSecurity();
+
+        /// <summary>
+        /// Benchmarks a matrix inversion using <see cref="OpCodes.Calli"/>.
+        /// </summary>
+        /// <returns>An inverted matrix.</returns>
+        [Benchmark]
+        public abstract Matrix2 Calli();
+
+        /// <summary>
+        /// Benchmarks a matrix inversion using a managed implementation.
+        /// </summary>
+        /// <returns>An inverted matrix.</returns>
+        [Benchmark]
+        public abstract Matrix2 Managed();
+    }
+}

--- a/AdvancedDLSupport.Benchmark/Benchmarks/InteropMethodsByRef.cs
+++ b/AdvancedDLSupport.Benchmark/Benchmarks/InteropMethodsByRef.cs
@@ -22,34 +22,19 @@ using AdvancedDLSupport.Benchmark.Native;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Exporters;
 using BenchmarkDotNet.Attributes.Jobs;
+using JetBrains.Annotations;
 
 #pragma warning disable CS1591, SA1600
 
 namespace AdvancedDLSupport.Benchmark.Benchmarks
 {
+    [UsedImplicitly]
     [ClrJob, CoreJob, MonoJob]
     [RPlotExporter, CsvMeasurementsExporter]
-    public class InteropMethodsByRef
+    public class InteropMethodsByRef : BenchmarkBase
     {
-        private static readonly Matrix2 Source = new Matrix2 { Row0 = { X = 4, Y = 7 }, Row1 = { X = 2, Y = 6 } };
-
-        private static ITest _adlLibrary;
-        private static ITest _adlLibraryWithoutDisposeChecks;
-        private static ITest _adlLibraryWithCalli;
-
-        /// <summary>
-        /// Initializes the local data neccesary to run tests.
-        /// </summary>
-        [GlobalSetup]
-        public void Setup()
-        {
-            _adlLibrary = NativeLibraryBuilder.Default.ActivateInterface<ITest>(Program.LibraryName);
-            _adlLibraryWithoutDisposeChecks = new NativeLibraryBuilder().ActivateInterface<ITest>(Program.LibraryName);
-            _adlLibraryWithCalli = new NativeLibraryBuilder(ImplementationOptions.UseIndirectCalls).ActivateInterface<ITest>(Program.LibraryName);
-        }
-
         [Benchmark]
-        public static Matrix2 DllImport()
+        public override Matrix2 DllImport()
         {
             var matrixCopy = Source;
             DllImportTest.InvertMatrixByPtr(ref matrixCopy);
@@ -58,34 +43,52 @@ namespace AdvancedDLSupport.Benchmark.Benchmarks
         }
 
         [Benchmark]
-        public static Matrix2 Delegates()
+        public override Matrix2 DllImportSuppressedSecurity()
         {
             var matrixCopy = Source;
-            _adlLibrary.InvertMatrixByPtr(ref matrixCopy);
+            DllImportTestSuppressedSecurity.InvertMatrixByPtr(ref matrixCopy);
 
             return matrixCopy;
         }
 
         [Benchmark]
-        public static Matrix2 DelegatesNoDispose()
+        public override Matrix2 Delegates()
         {
             var matrixCopy = Source;
-            _adlLibraryWithoutDisposeChecks.InvertMatrixByPtr(ref matrixCopy);
+            ADLLibrary.InvertMatrixByPtr(ref matrixCopy);
 
             return matrixCopy;
         }
 
         [Benchmark]
-        public static Matrix2 Calli()
+        public override Matrix2 DelegatesNoDispose()
         {
             var matrixCopy = Source;
-            _adlLibraryWithCalli.InvertMatrixByPtr(ref matrixCopy);
+            ADLLibraryWithoutDisposeChecks.InvertMatrixByPtr(ref matrixCopy);
 
             return matrixCopy;
         }
 
         [Benchmark]
-        public static Matrix2 Managed()
+        public override Matrix2 DelegatesSuppressedSecurity()
+        {
+            var matrixCopy = Source;
+            ADLLibraryWithSuppressedSecurity.InvertMatrixByPtr(ref matrixCopy);
+
+            return matrixCopy;
+        }
+
+        [Benchmark]
+        public override Matrix2 Calli()
+        {
+            var matrixCopy = Source;
+            ADLLibraryWithCalli.InvertMatrixByPtr(ref matrixCopy);
+
+            return matrixCopy;
+        }
+
+        [Benchmark]
+        public override Matrix2 Managed()
         {
             var matrixCopy = Source;
             Matrix2.Invert(ref matrixCopy);

--- a/AdvancedDLSupport.Benchmark/Native/DllImportTestSuppressedSecurity.cs
+++ b/AdvancedDLSupport.Benchmark/Native/DllImportTestSuppressedSecurity.cs
@@ -1,0 +1,46 @@
+﻿//
+//  DllImportTestSuppressedSecurity.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.InteropServices;
+using System.Security;
+using AdvancedDLSupport.Benchmark.Data;
+
+namespace AdvancedDLSupport.Benchmark.Native
+{
+    /// <summary>
+    /// <see cref="DllImportAttribute"/> interop methods with suppressed unmanaged code security.
+    /// </summary>
+    internal static class DllImportTestSuppressedSecurity
+    {
+        /// <summary>
+        /// Inverts a given by-reference <see cref="Matrix2"/>.
+        /// </summary>
+        /// <param name="matrix">The matrix.</param>
+        [DllImport(Program.LibraryName), SuppressUnmanagedCodeSecurity]
+        public static extern void InvertMatrixByPtr(ref Matrix2 matrix);
+
+        /// <summary>
+        /// Inverts a given by-value <see cref="Matrix2"/>.
+        /// </summary>
+        /// <param name="matrix">The matrix.</param>
+        /// <returns>The inverted matrix.</returns>
+        [DllImport(Program.LibraryName), SuppressUnmanagedCodeSecurity]
+        public static extern Matrix2 InvertMatrixByValue(Matrix2 matrix);
+    }
+}

--- a/AdvancedDLSupport.Benchmark/Program.cs
+++ b/AdvancedDLSupport.Benchmark/Program.cs
@@ -48,7 +48,7 @@ namespace AdvancedDLSupport.Benchmark
                     b =>
                     {
                         var isClrJob = b.Job.Env.Runtime.Name == "Clr";
-                        var isRunningOnMono = Type.GetType("Mono.Runtime") is null;
+                        var isRunningOnMono = !(Type.GetType("Mono.Runtime") is null);
 
                         if (!isClrJob)
                         {

--- a/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
+++ b/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
@@ -223,6 +223,9 @@
   <member name="F:AdvancedDLSupport.ImplementationOptions.GenerateDisposalChecks">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>
+  <member name="F:AdvancedDLSupport.ImplementationOptions.SuppressSecurity">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+  </member>
   <member name="F:AdvancedDLSupport.ImplementationOptions.UseIndirectCalls">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>

--- a/AdvancedDLSupport/ImplementationGenerators/Transforming/LoweredMethodImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Transforming/LoweredMethodImplementationGenerator.cs
@@ -26,10 +26,7 @@ using AdvancedDLSupport.Extensions;
 using AdvancedDLSupport.Pipeline;
 using AdvancedDLSupport.Reflection;
 using JetBrains.Annotations;
-using Mono.DllMap.Extensions;
-
 using static AdvancedDLSupport.ImplementationGenerators.GeneratorComplexity;
-using static AdvancedDLSupport.ImplementationOptions;
 using static System.Reflection.MethodAttributes;
 
 namespace AdvancedDLSupport.ImplementationGenerators

--- a/AdvancedDLSupport/ImplementationOptions.cs
+++ b/AdvancedDLSupport/ImplementationOptions.cs
@@ -56,6 +56,12 @@ namespace AdvancedDLSupport
         /// Enables code optimizations for the generated assembly.
         /// </summary>
         [PublicAPI]
-        EnableOptimizations = 1 << 4
+        EnableOptimizations = 1 << 4,
+
+        /// <summary>
+        /// Suppresses code security whenever possible.
+        /// </summary>
+        [PublicAPI]
+        SuppressSecurity = 1 << 5
     }
 }

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -89,7 +89,7 @@ namespace AdvancedDLSupport
 
             Default = new NativeLibraryBuilder
             (
-                GenerateDisposalChecks | EnableDllMapSupport | EnableOptimizations
+                GenerateDisposalChecks | EnableDllMapSupport | EnableOptimizations | SuppressSecurity
             );
         }
 


### PR DESCRIPTION
### Purpose of this PR

This PR implements optional suppression of unmanaged code security in order to get some additional speed gains.

The following is a benchmark of code with or without suppressed security.

```
BenchmarkDotNet=v0.10.14, OS=linuxmint 18.3
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
  [Host] : Mono 5.10.1.47 (tarball Wed), 64bit 
  Mono   : Mono 5.10.1.47 (tarball Wed), 64bit 


                      Method |  Job | Runtime |        Mean |     Error |    StdDev |
---------------------------- |----- |-------- |------------:|----------:|----------:|
                   DllImport | Mono |    Mono |    27.75 ns | 0.5732 ns | 0.8221 ns |
 DllImportSuppressedSecurity | Mono |    Mono |    26.70 ns | 0.0337 ns | 0.0315 ns |
                   Delegates | Mono |    Mono | 1,222.49 ns | 3.0789 ns | 2.8800 ns |
          DelegatesNoDispose | Mono |    Mono | 1,211.93 ns | 1.4629 ns | 1.2216 ns |
 DelegatesSuppressedSecurity | Mono |    Mono |   982.23 ns | 1.8489 ns | 1.6390 ns |
                       Calli | Mono |    Mono |    26.77 ns | 0.0230 ns | 0.0204 ns |
                     Managed | Mono |    Mono |    28.24 ns | 0.0151 ns | 0.0133 ns |

```