### PR TITLE
Add probing step for native directories as defined in the app context

### DIFF
--- a/AdvancedDLSupport/PathResolvers/DynamicLinkLibraryPathResolver.cs
+++ b/AdvancedDLSupport/PathResolvers/DynamicLinkLibraryPathResolver.cs
@@ -112,6 +112,23 @@ namespace AdvancedDLSupport
                 }
             }
 
+            // Check the native probing paths (.NET Core defines this, Mono doesn't. Users can set this at runtime, too)
+            if (AppContext.GetData("NATIVE_DLL_SEARCH_DIRECTORIES") is string directories)
+            {
+                var paths = directories.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var path in paths)
+                {
+                    foreach (var candidate in candidates)
+                    {
+                        var candidatePath = Path.Combine(path, candidate);
+                        if (File.Exists(candidatePath))
+                        {
+                            return ResolvePathResult.FromSuccess(Path.GetFullPath(candidatePath));
+                        }
+                    }
+                }
+            }
+
             if (localFirst)
             {
                 foreach (var candidate in candidates)


### PR DESCRIPTION
This PR adds additional probing logic that checks the `NATIVE_DLL_SEARCH_DIRECTORIES` property on the app context for defined probling folders.

Thanks to @pauldotknopf for finding the API!
Fixes #42.