### PR TITLE
Hybrid class interface discovery

### DIFF
--- a/AdvancedDLSupport.AOT/AdvancedDLSupport.AOT.ExternalAnnotations.xml
+++ b/AdvancedDLSupport.AOT/AdvancedDLSupport.AOT.ExternalAnnotations.xml
@@ -44,13 +44,13 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
-  <member name="M:AdvancedDLSupport.AOT.PregeneratedAssemblyBuilder.WithSourceExplicitTypeCombination(System.Type,System.Type)">
+  <member name="M:AdvancedDLSupport.AOT.PregeneratedAssemblyBuilder.WithSourceExplicitTypeCombination(System.Type,System.Type[])">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     <parameter name="classType">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
-    <parameter name="interfaceType">
+    <parameter name="interfaceTypes">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>

--- a/AdvancedDLSupport.AOT/AdvancedDLSupport.AOT.csproj
+++ b/AdvancedDLSupport.AOT/AdvancedDLSupport.AOT.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <Title>AdvancedDLSupport.AOT</Title>
     <Authors>TheBlackCentipede;Jax</Authors>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
     <Description>An alternative approach to your typical P/Invoke.</Description>
     <Copyright>Copyright Firwood Software 2017</Copyright>
   </PropertyGroup>

--- a/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithMultipleNativeInterfaces.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithMultipleNativeInterfaces.cs
@@ -1,0 +1,60 @@
+//
+//  MixedModeClassWithMultipleNativeInterfaces.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+
+#pragma warning disable SA1600, CS1591
+
+// ReSharper disable ValueParameterNotUsed
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+    public abstract class MixedModeClassWithMultipleNativeInterfaces : NativeLibraryBase, IMixedModeLibraryFunctions, IMixedModeLibraryProperties
+    {
+        public MixedModeClassWithMultipleNativeInterfaces(string path, Type interfaceType, ImplementationOptions options)
+            : base(path, options)
+        {
+        }
+
+        public bool RanManagedSubtract { get; private set; }
+
+        public bool RanManagedSetter { get; private set; }
+
+        public int ManagedAdd(int a, int b)
+        {
+            return a + b;
+        }
+
+        public int OtherNativeProperty
+        {
+            get => 32;
+
+            set => RanManagedSetter = true;
+        }
+
+        public abstract int NativeProperty { get; set; }
+
+        public abstract int Multiply(int value, int multiplier);
+
+        public int Subtract(int value, int other)
+        {
+            RanManagedSubtract = true;
+            return value - other;
+        }
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryFunctions.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryFunctions.cs
@@ -1,0 +1,30 @@
+﻿//
+//  IMixedModeLibraryFunctions.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IMixedModeLibraryFunctions
+    {
+        int Multiply(int a, int b);
+
+        int Subtract(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryProperties.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryProperties.cs
@@ -1,0 +1,30 @@
+﻿//
+//  IMixedModeLibraryProperties.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IMixedModeLibraryProperties
+    {
+        int NativeProperty { get; set; }
+
+        int OtherNativeProperty { get; set; }
+    }
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
@@ -37,7 +37,7 @@ namespace AdvancedDLSupport.Tests.Integration
         {
             _builder = new NativeLibraryBuilder(ImplementationOptions.GenerateDisposalChecks);
 
-            _mixedModeClass = _builder.ActivateClass<MixedModeClass, IMixedModeLibrary>(LibraryName);
+            _mixedModeClass = _builder.ActivateClass<MixedModeClass>(LibraryName);
         }
 
         [Fact]
@@ -46,8 +46,14 @@ namespace AdvancedDLSupport.Tests.Integration
             Assert.Throws<ArgumentException>
             (
                 () =>
-                    _builder.ActivateClass<MixedModeClassThatIsNotAbstract, IMixedModeLibrary>(LibraryName)
+                    _builder.ActivateClass<MixedModeClassThatIsNotAbstract>(LibraryName)
             );
+        }
+
+        [Fact]
+        public void CanActivateClassWithMultipleNativeInterfaces()
+        {
+            _builder.ActivateClass<MixedModeClassWithMultipleNativeInterfaces>(LibraryName);
         }
 
         [Fact]

--- a/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
+++ b/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
@@ -393,6 +393,26 @@
       <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
+  <member name="M:AdvancedDLSupport.NativeLibraryBuilder.ActivateClass(System.String,System.Type,System.Type[])">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <parameter name="libraryPath">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+    <parameter name="baseClassType">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+    <parameter name="interfaceTypes">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
+  <member name="M:AdvancedDLSupport.NativeLibraryBuilder.ActivateClass``1(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <parameter name="libraryPath">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
   <member name="M:AdvancedDLSupport.NativeLibraryBuilder.ActivateClass``2(System.String)">
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -343,22 +343,6 @@ namespace AdvancedDLSupport
         /// <summary>
         /// Generates the implementation type for a given class and interface combination, caching it for later use.
         /// </summary>
-        /// <typeparam name="TBaseClass">The base class for the implementation to generate.</typeparam>
-        /// <typeparam name="TInterface">The interface to implement.</typeparam>
-        /// <exception cref="ArgumentException">Thrown if either of the type arguments are incompatible.</exception>
-        /// <exception cref="FileNotFoundException">
-        /// Thrown if the specified library can't be found in any of the loader paths.
-        /// </exception>
-        internal void PregenerateImplementationType<TBaseClass, TInterface>()
-            where TBaseClass : NativeLibraryBase
-            where TInterface : class
-        {
-            PregenerateImplementationType(typeof(TBaseClass), typeof(TInterface));
-        }
-
-        /// <summary>
-        /// Generates the implementation type for a given class and interface combination, caching it for later use.
-        /// </summary>
         /// <param name="classType">The base class for the implementation to generate.</param>
         /// <param name="interfaceTypes">The interfaces to implement.</param>
         /// <exception cref="ArgumentException">Thrown if either of the type arguments are incompatible.</exception>
@@ -415,40 +399,6 @@ namespace AdvancedDLSupport
             }
 
             return new Tuple<GeneratedImplementationTypeIdentifier, Type>(key, generatedType);
-        }
-
-        /// <summary>
-        /// Generates a type inheriting from the given class and implementing the given interface, setting it up to bind
-        /// the interface functions to native C code.
-        /// </summary>
-        /// <typeparam name="TBaseClass">The base class of the type to generate.</typeparam>
-        /// <typeparam name="TInterface">The interface that the type should implement.</typeparam>
-        /// <returns>The type.</returns>
-        [NotNull, Pure]
-        private Type GenerateInterfaceImplementationType<TBaseClass, TInterface>()
-            where TBaseClass : NativeLibraryBase
-            where TInterface : class
-        {
-            var baseClassType = typeof(TBaseClass);
-            var interfaceType = typeof(TInterface);
-
-            return GenerateInterfaceImplementationType(baseClassType, interfaceType);
-        }
-
-        /// <summary>
-        /// Generates a type inheriting from the given class and implementing the given interface, setting it up to bind
-        /// the interface functions to native C code.
-        /// </summary>
-        /// <typeparam name="TBaseClass">The base class of the type to generate.</typeparam>
-        /// <param name="interfaceTypes">The interfaces that the type should implement.</param>
-        /// <returns>The type.</returns>
-        [NotNull, Pure]
-        private Type GenerateInterfaceImplementationType<TBaseClass>([NotNull] Type[] interfaceTypes)
-            where TBaseClass : NativeLibraryBase
-        {
-            var baseClassType = typeof(TBaseClass);
-
-            return GenerateInterfaceImplementationType(baseClassType, interfaceTypes);
         }
 
         /// <summary>

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -182,6 +182,12 @@ namespace AdvancedDLSupport
         [NotNull, PublicAPI]
         public TInterface ActivateInterface<TInterface>([NotNull] string libraryPath) where TInterface : class
         {
+            // Check for remapping
+            if (Options.HasFlagFast(EnableDllMapSupport))
+            {
+                libraryPath = new DllMapResolver().MapLibraryName(typeof(TInterface), libraryPath);
+            }
+
             var anonymousInstance = ActivateClass<NativeLibraryBase, TInterface>(libraryPath);
 
             return anonymousInstance as TInterface
@@ -192,7 +198,36 @@ namespace AdvancedDLSupport
         }
 
         /// <summary>
-        /// Resolves a mixed-mode class that implementing a C function interface, making the native functions available
+        /// Resolves a mixed-mode class that implements a C function interface, making the native functions available
+        /// for use.
+        /// </summary>
+        /// <param name="libraryPath">The name of or path to the library.</param>
+        /// <typeparam name="TClass">The base class for the implementation to generate.</typeparam>
+        /// <returns>An instance of the class.</returns>
+        /// <exception cref="ArgumentException">Thrown if either of the type arguments are incompatible.</exception>
+        /// <exception cref="FileNotFoundException">
+        /// Thrown if the specified library can't be found in any of the loader paths.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the resulting instance can't be cast to the expected class. Should never occur in user code.
+        /// </exception>
+        [NotNull, PublicAPI]
+        public TClass ActivateClass<TClass>([NotNull] string libraryPath)
+            where TClass : NativeLibraryBase
+        {
+            var classType = typeof(TClass);
+
+            // Check for remapping
+            if (Options.HasFlagFast(EnableDllMapSupport))
+            {
+                libraryPath = new DllMapResolver().MapLibraryName(classType, libraryPath);
+            }
+
+            return (TClass)ActivateClass(libraryPath, classType, classType.GetInterfaces());
+        }
+
+        /// <summary>
+        /// Resolves a mixed-mode class that implements a C function interface, making the native functions available
         /// for use.
         /// </summary>
         /// <param name="libraryPath">The name of or path to the library.</param>
@@ -212,25 +247,49 @@ namespace AdvancedDLSupport
             where TInterface : class
         {
             var classType = typeof(TClass);
-            if (!classType.IsAbstract)
-            {
-                throw new ArgumentException("The class to activate must be abstract.", nameof(TClass));
-            }
-
-            var interfaceType = typeof(TInterface);
-            if (!interfaceType.IsInterface)
-            {
-                throw new ArgumentException
-                (
-                    "The interface to activate on the class must be an interface type.",
-                    nameof(TInterface)
-                );
-            }
 
             // Check for remapping
             if (Options.HasFlagFast(EnableDllMapSupport))
             {
-                libraryPath = new DllMapResolver().MapLibraryName(interfaceType, libraryPath);
+                libraryPath = new DllMapResolver().MapLibraryName(classType, libraryPath);
+            }
+
+            return (TClass)ActivateClass(libraryPath, classType, typeof(TInterface));
+        }
+
+        /// <summary>
+        /// Resolves a mixed-mode class that implements a C function interface, making the native functions available
+        /// for use.
+        /// </summary>
+        /// <param name="libraryPath">The name of or path to the library.</param>
+        /// <param name="baseClassType">The base class for the implementation to generate.</param>
+        /// <param name="interfaceTypes">The interfaces to implement.</param>
+        /// <returns>An instance of the class.</returns>
+        /// <exception cref="ArgumentException">Thrown if either of the type arguments are incompatible.</exception>
+        /// <exception cref="FileNotFoundException">
+        /// Thrown if the specified library can't be found in any of the loader paths.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if the resulting instance can't be cast to the expected class. Should never occur in user code.
+        /// </exception>
+        [NotNull, PublicAPI]
+        public object ActivateClass
+        (
+            [NotNull] string libraryPath, [NotNull] Type baseClassType, [NotNull] params Type[] interfaceTypes
+        )
+        {
+            if (!baseClassType.IsAbstract)
+            {
+                throw new ArgumentException("The class to activate must be abstract.", nameof(baseClassType));
+            }
+
+            if (!interfaceTypes.Any(i => i.IsInterface))
+            {
+                throw new ArgumentException
+                (
+                    "The interfaces to activate on the class must be an interface type.",
+                    nameof(interfaceTypes)
+                );
             }
 
             // Attempt to resolve a name or path for the given library
@@ -248,29 +307,25 @@ namespace AdvancedDLSupport
             libraryPath = resolveResult.Path;
 
             // Check if we've already generated a type for this configuration
-            var key = new GeneratedImplementationTypeIdentifier(classType, interfaceType, Options);
+            var key = new GeneratedImplementationTypeIdentifier(baseClassType, interfaceTypes, Options);
             lock (BuilderLock)
             {
                 if (!TypeCache.TryGetValue(key, out var generatedType))
                 {
-                    generatedType = GenerateInterfaceImplementationType<TClass, TInterface>();
+                    generatedType = GenerateInterfaceImplementationType(baseClassType, interfaceTypes);
                     TypeCache.TryAdd(key, generatedType);
                 }
 
                 try
                 {
-                    var anonymousInstance = CreateAnonymousImplementationInstance<TInterface>
+                    var anonymousInstance = CreateAnonymousImplementationInstance
                     (
                         generatedType,
                         libraryPath,
                         Options
                     );
 
-                    return anonymousInstance as TClass
-                    ?? throw new InvalidOperationException
-                    (
-                        "The resulting instance was not convertible to an instance of the class."
-                    );
+                    return anonymousInstance;
                 }
                 catch (TargetInvocationException tex)
                 {
@@ -298,45 +353,14 @@ namespace AdvancedDLSupport
             where TBaseClass : NativeLibraryBase
             where TInterface : class
         {
-            var classType = typeof(TBaseClass);
-            if (!classType.IsAbstract)
-            {
-                throw new ArgumentException
-                (
-                    "The class to activate must be abstract.",
-                    nameof(TBaseClass)
-                );
-            }
-
-            var interfaceType = typeof(TInterface);
-            if (!interfaceType.IsInterface)
-            {
-                throw new ArgumentException
-                (
-                    "The interface to activate on the class must be an interface type.",
-                    nameof(TInterface)
-                );
-            }
-
-            // Check if we've already generated a type for this configuration
-            var key = new GeneratedImplementationTypeIdentifier(classType, interfaceType, Options);
-            lock (BuilderLock)
-            {
-                if (TypeCache.TryGetValue(key, out var generatedType))
-                {
-                    return;
-                }
-
-                generatedType = GenerateInterfaceImplementationType<TBaseClass, TInterface>();
-                TypeCache.TryAdd(key, generatedType);
-            }
+            PregenerateImplementationType(typeof(TBaseClass), typeof(TInterface));
         }
 
         /// <summary>
         /// Generates the implementation type for a given class and interface combination, caching it for later use.
         /// </summary>
         /// <param name="classType">The base class for the implementation to generate.</param>
-        /// <param name="interfaceType">The interface to implement.</param>
+        /// <param name="interfaceTypes">The interfaces to implement.</param>
         /// <exception cref="ArgumentException">Thrown if either of the type arguments are incompatible.</exception>
         /// <exception cref="FileNotFoundException">
         /// Thrown if the specified library can't be found in any of the loader paths.
@@ -346,7 +370,7 @@ namespace AdvancedDLSupport
         internal Tuple<GeneratedImplementationTypeIdentifier, Type> PregenerateImplementationType
         (
             [NotNull] Type classType,
-            [NotNull] Type interfaceType
+            [NotNull] params Type[] interfaceTypes
         )
         {
             if (!classType.IsAbstract)
@@ -367,17 +391,17 @@ namespace AdvancedDLSupport
                 );
             }
 
-            if (!interfaceType.IsInterface)
+            if (!interfaceTypes.Any(i => i.IsInterface))
             {
                 throw new ArgumentException
                 (
-                    "The interface to activate on the class must be an interface type.",
-                    nameof(interfaceType)
+                    "The interfaces to activate on the class must be an interface type.",
+                    nameof(interfaceTypes)
                 );
             }
 
             // Check if we've already generated a type for this configuration
-            var key = new GeneratedImplementationTypeIdentifier(classType, interfaceType, Options);
+            var key = new GeneratedImplementationTypeIdentifier(classType, interfaceTypes, Options);
             Type generatedType;
             lock (BuilderLock)
             {
@@ -386,7 +410,7 @@ namespace AdvancedDLSupport
                     return new Tuple<GeneratedImplementationTypeIdentifier, Type>(key, generatedType);
                 }
 
-                generatedType = GenerateInterfaceImplementationType(classType, interfaceType);
+                generatedType = GenerateInterfaceImplementationType(classType, interfaceTypes);
                 TypeCache.TryAdd(key, generatedType);
             }
 
@@ -415,11 +439,31 @@ namespace AdvancedDLSupport
         /// Generates a type inheriting from the given class and implementing the given interface, setting it up to bind
         /// the interface functions to native C code.
         /// </summary>
-        /// <param name="classType">The base class for the implementation to generate.</param>
-        /// <param name="interfaceType">The interface to implement.</param>
+        /// <typeparam name="TBaseClass">The base class of the type to generate.</typeparam>
+        /// <param name="interfaceTypes">The interfaces that the type should implement.</param>
         /// <returns>The type.</returns>
         [NotNull, Pure]
-        private Type GenerateInterfaceImplementationType([NotNull] Type classType, [NotNull] Type interfaceType)
+        private Type GenerateInterfaceImplementationType<TBaseClass>([NotNull] Type[] interfaceTypes)
+            where TBaseClass : NativeLibraryBase
+        {
+            var baseClassType = typeof(TBaseClass);
+
+            return GenerateInterfaceImplementationType(baseClassType, interfaceTypes);
+        }
+
+        /// <summary>
+        /// Generates a type inheriting from the given class and implementing the given interface, setting it up to bind
+        /// the interface functions to native C code.
+        /// </summary>
+        /// <param name="classType">The base class for the implementation to generate.</param>
+        /// <param name="interfaceTypes">The interfaces to implement.</param>
+        /// <returns>The type.</returns>
+        [NotNull, Pure]
+        private Type GenerateInterfaceImplementationType
+        (
+            [NotNull] Type classType,
+            [NotNull] params Type[] interfaceTypes
+        )
         {
             if (!classType.IsAbstract)
             {
@@ -439,16 +483,16 @@ namespace AdvancedDLSupport
                 );
             }
 
-            if (!interfaceType.IsInterface)
+            if (!interfaceTypes.Any(i => i.IsInterface))
             {
                 throw new ArgumentException
                 (
                     "The interface to activate on the class must be an interface type.",
-                    nameof(interfaceType)
+                    nameof(interfaceTypes)
                 );
             }
 
-            var typeName = GenerateTypeName(interfaceType);
+            var typeName = GenerateTypeName(classType);
 
             // Create a new type for the anonymous implementation
             var typeBuilder = _moduleBuilder.DefineType
@@ -456,7 +500,7 @@ namespace AdvancedDLSupport
                 typeName,
                 TypeAttributes.AutoClass | TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed,
                 classType,
-                new[] { interfaceType }
+                interfaceTypes
             );
 
             // Now the constructor
@@ -491,8 +535,8 @@ namespace AdvancedDLSupport
                 Options
             );
 
-            ConstructMethods(pipeline, classType, interfaceType);
-            ConstructProperties(pipeline, classType, interfaceType);
+            ConstructMethods(pipeline, classType, interfaceTypes);
+            ConstructProperties(pipeline, classType, interfaceTypes);
 
             constructorIL.Emit(OpCodes.Ret);
             return typeBuilder.CreateTypeInfo();
@@ -536,7 +580,25 @@ namespace AdvancedDLSupport
             ImplementationOptions options
         )
         {
-            return (TInterface)Activator.CreateInstance
+            return (TInterface)CreateAnonymousImplementationInstance(finalType, library, options);
+        }
+
+        /// <summary>
+        /// Creates an instance of the final implementation type.
+        /// </summary>
+        /// <param name="finalType">The constructed anonymous type.</param>
+        /// <param name="library">The path to or name of the library</param>
+        /// <param name="options">The generator options.</param>
+        /// <returns>An instance of the anonymous type.</returns>
+        [NotNull]
+        private object CreateAnonymousImplementationInstance
+        (
+            [NotNull] Type finalType,
+            [NotNull] string library,
+            ImplementationOptions options
+        )
+        {
+            return Activator.CreateInstance
             (
                 finalType,
                 library,
@@ -549,53 +611,56 @@ namespace AdvancedDLSupport
         /// </summary>
         /// <param name="pipeline">The implementation pipeline that consumes the methods.</param>
         /// <param name="classType">The base class of the type to generate methods for.</param>
-        /// <param name="interfaceType">The interface where the methods originate.</param>
+        /// <param name="interfaceTypes">The interfaces where the methods originate.</param>
         private void ConstructMethods
         (
             [NotNull] ImplementationPipeline pipeline,
             [NotNull] Type classType,
-            [NotNull] Type interfaceType
+            [NotNull] params Type[] interfaceTypes
         )
         {
             var symbolTransformer = SymbolTransformer.Default;
             var methods = new List<PipelineWorkUnit<IntrospectiveMethodInfo>>();
-            foreach (var method in interfaceType.GetIntrospectiveMethods(true))
+            foreach (var interfaceType in interfaceTypes)
             {
-                var targetMethod = method;
-
-                // Skip any property accessor methods
-                if (method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_")))
+                foreach (var method in interfaceType.GetIntrospectiveMethods(true))
                 {
-                    continue;
-                }
+                    var targetMethod = method;
 
-                // Skip methods with a managed implementation in the base class
-                var baseClassMethod = classType.GetIntrospectiveMethod
-                (
-                    method.Name,
-                    method.ParameterTypes.ToArray()
-                );
-
-                if (!(baseClassMethod is null))
-                {
-                    if (!baseClassMethod.IsAbstract)
+                    // Skip any property accessor methods
+                    if (method.IsSpecialName && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_")))
                     {
                         continue;
                     }
 
-                    targetMethod = baseClassMethod;
-                }
-
-                var definition = pipeline.GenerateDefinitionFromSignature(targetMethod);
-                methods.Add
-                (
-                    new PipelineWorkUnit<IntrospectiveMethodInfo>
+                    // Skip methods with a managed implementation in the base class
+                    var baseClassMethod = classType.GetIntrospectiveMethod
                     (
-                        definition,
-                        symbolTransformer.GetTransformedSymbol(interfaceType, definition),
-                        Options
-                    )
-                );
+                        method.Name,
+                        method.ParameterTypes.ToArray()
+                    );
+
+                    if (!(baseClassMethod is null))
+                    {
+                        if (!baseClassMethod.IsAbstract)
+                        {
+                            continue;
+                        }
+
+                        targetMethod = baseClassMethod;
+                    }
+
+                    var definition = pipeline.GenerateDefinitionFromSignature(targetMethod);
+                    methods.Add
+                    (
+                        new PipelineWorkUnit<IntrospectiveMethodInfo>
+                        (
+                            definition,
+                            symbolTransformer.GetTransformedSymbol(interfaceType, definition),
+                            Options
+                        )
+                    );
+                }
             }
 
             pipeline.ConsumeMethodDefinitions(methods);
@@ -606,7 +671,7 @@ namespace AdvancedDLSupport
         /// </summary>
         /// <param name="pipeline">The implementation pipeline that consumes the methods.</param>
         /// <param name="classType">The base class of the type to generator properties for.</param>
-        /// <param name="interfaceType">The interface where the properties originate.</param>
+        /// <param name="interfaceTypes">The interfaces where the properties originate.</param>
         /// <exception cref="InvalidOperationException">
         /// Thrown if any property is declared as partially abstract.
         /// </exception>
@@ -614,51 +679,54 @@ namespace AdvancedDLSupport
         (
             [NotNull] ImplementationPipeline pipeline,
             [NotNull] Type classType,
-            [NotNull] Type interfaceType
+            [NotNull] params Type[] interfaceTypes
         )
         {
             var symbolTransformer = SymbolTransformer.Default;
             var properties = new List<PipelineWorkUnit<IntrospectivePropertyInfo>>();
-            foreach (var property in interfaceType.GetProperties())
+            foreach (var interfaceType in interfaceTypes)
             {
-                var targetProperty = property;
-
-                // Skip properties with a managed implementation
-                var baseClassProperty = classType.GetProperty(property.Name, property.PropertyType);
-                if (!(baseClassProperty is null))
+                foreach (var property in interfaceType.GetProperties())
                 {
-                    var isFullyManaged = !baseClassProperty.GetGetMethod().IsAbstract &&
-                                         !baseClassProperty.GetSetMethod().IsAbstract;
+                    var targetProperty = property;
 
-                    if (isFullyManaged)
+                    // Skip properties with a managed implementation
+                    var baseClassProperty = classType.GetProperty(property.Name, property.PropertyType);
+                    if (!(baseClassProperty is null))
                     {
-                        continue;
+                        var isFullyManaged = !baseClassProperty.GetGetMethod().IsAbstract &&
+                                             !baseClassProperty.GetSetMethod().IsAbstract;
+
+                        if (isFullyManaged)
+                        {
+                            continue;
+                        }
+
+                        var isPartiallyAbstract = baseClassProperty.GetGetMethod().IsAbstract ^
+                                                  baseClassProperty.GetSetMethod().IsAbstract;
+
+                        if (isPartiallyAbstract)
+                        {
+                            throw new InvalidOperationException
+                            (
+                                "Properties with overriding managed implementations may not be partially managed."
+                            );
+                        }
+
+                        targetProperty = baseClassProperty;
                     }
 
-                    var isPartiallyAbstract = baseClassProperty.GetGetMethod().IsAbstract ^
-                                              baseClassProperty.GetSetMethod().IsAbstract;
-
-                    if (isPartiallyAbstract)
-                    {
-                        throw new InvalidOperationException
-                        (
-                            "Properties with overriding managed implementations may not be partially managed."
-                        );
-                    }
-
-                    targetProperty = baseClassProperty;
-                }
-
-                var definition = new IntrospectivePropertyInfo(targetProperty);
-                properties.Add
-                (
-                    new PipelineWorkUnit<IntrospectivePropertyInfo>
+                    var definition = new IntrospectivePropertyInfo(targetProperty);
+                    properties.Add
                     (
-                        definition,
-                        symbolTransformer.GetTransformedSymbol(interfaceType, definition),
-                        Options
-                    )
-                );
+                        new PipelineWorkUnit<IntrospectivePropertyInfo>
+                        (
+                            definition,
+                            symbolTransformer.GetTransformedSymbol(interfaceType, definition),
+                            Options
+                        )
+                    );
+                }
             }
 
             pipeline.ConsumePropertyDefinitions(properties);

--- a/AdvancedDLSupport/Reflection/IntrospectiveMethodInfo.cs
+++ b/AdvancedDLSupport/Reflection/IntrospectiveMethodInfo.cs
@@ -167,7 +167,13 @@ namespace AdvancedDLSupport.Reflection
 
                 if (returnParameterMarshalAsAttribute is null && RuntimeInformation.FrameworkDescription.Contains("Mono"))
                 {
-                    returnParameterMarshalAsAttribute = Attribute.GetCustomAttribute(methodInfo.ReturnParameter, typeof(MarshalAsAttribute)) as MarshalAsAttribute;
+                    // Don't walk the inheritance tree of the return parameter due to a bug
+                    // https://stackoverflow.com/a/38759885
+                    returnParameterMarshalAsAttribute = Attribute.GetCustomAttribute
+                    (
+                        methodInfo.ReturnParameter, typeof(MarshalAsAttribute), false
+                    ) as MarshalAsAttribute;
+
                     if (!(returnParameterMarshalAsAttribute is null))
                     {
                         returnCustomAttributes.Add(returnParameterMarshalAsAttribute.GetAttributeData());

--- a/AdvancedDLSupport/Utility/GeneratedImplementationTypeIdentifier.cs
+++ b/AdvancedDLSupport/Utility/GeneratedImplementationTypeIdentifier.cs
@@ -18,6 +18,8 @@
 //
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 
 namespace AdvancedDLSupport
@@ -36,12 +38,12 @@ namespace AdvancedDLSupport
         public GeneratedImplementationTypeIdentifier
         (
             [NotNull] Type baseClassType,
-            [NotNull] Type interfaceType,
+            [NotNull] IReadOnlyList<Type> interfaceType,
             ImplementationOptions options
         )
         {
             BaseClassType = baseClassType;
-            InterfaceType = interfaceType;
+            InterfaceTypes = interfaceType;
             Options = options;
         }
 
@@ -53,7 +55,7 @@ namespace AdvancedDLSupport
         /// <summary>
         /// Gets the interface type for the library.
         /// </summary>
-        internal Type InterfaceType { get; }
+        internal IReadOnlyList<Type> InterfaceTypes { get; }
 
         /// <summary>
         /// Gets the configuration used for the library at construction time.
@@ -65,7 +67,7 @@ namespace AdvancedDLSupport
         {
             return
                 BaseClassType == other.BaseClassType &&
-                InterfaceType == other.InterfaceType &&
+                InterfaceTypes.OrderBy(i => i.Name).SequenceEqual(other.InterfaceTypes.OrderBy(i => i.Name)) &&
                 Options == other.Options;
         }
 
@@ -86,8 +88,8 @@ namespace AdvancedDLSupport
             unchecked
             {
                 return
-                    ((BaseClassType != null ? InterfaceType.GetHashCode() : 0) * 397) ^
-                    ((InterfaceType != null ? InterfaceType.GetHashCode() : 0) * 397) ^
+                    ((BaseClassType != null ? InterfaceTypes.Sum(i => i.GetHashCode()) : 0) * 397) ^
+                    ((InterfaceTypes != null ? InterfaceTypes.Sum(i => i.GetHashCode()) : 0) * 397) ^
                     ((int)Options * 397);
             }
         }

--- a/docs/mixed_mode_classes.md
+++ b/docs/mixed_mode_classes.md
@@ -83,5 +83,8 @@ Once you have your class definition, instances of it can be created in much the 
 instances:
 
 ```cs
-NativeLibraryBuilder::ActivateClass<MixedModeClass, IMixedModeLibrary>(LibraryName);
+NativeLibraryBuilder::ActivateClass<MixedModeClass>(LibraryName);
 ```
+
+Mixed-mode classes can implement multiple native interfaces, benefit from inheritance, and use generics just as you'd 
+normally would.


### PR DESCRIPTION
### Purpose of this PR
This PR improves the way native interface members are implemented on mixed-mode classes, allowing the user to omit the target interface when instantiating the class.

Under the new system, way more configurations are supported - mixed-mode classes can implement multiple native interfaces, use inheritance of base mixed-mode classes, and can leverage generics better.

The old API remains in place for compatibility's sake.

### Testing status

* New tests have been added, and old tests have been modified to use the new system.

### Comments

Do note that this *breaks binary compatibility* with AOT-compiled assemblies due to internal changes in the library. If you're using the AOT module (which is unreleased as of yet and should be considered a beta), you'll need to regenerate your AOT assemblies.