### PR TITLE
Allow loading the main executable on platforms other than Mono

### DIFF
--- a/AdvanceDLSupport.sln.DotSettings
+++ b/AdvanceDLSupport.sln.DotSettings
@@ -32,4 +32,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Passthrough/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Passthrough/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=runtimes/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/AdvancedDLSupport.Tests/Tests/Integration/GenericDelegateTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/GenericDelegateTests.cs
@@ -17,7 +17,6 @@
 //  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-using System;
 using AdvancedDLSupport.Tests.Data;
 using AdvancedDLSupport.Tests.TestBases;
 using Xunit;

--- a/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
@@ -18,7 +18,6 @@
 //
 
 using System;
-using AdvancedDLSupport.Tests.Data;
 using AdvancedDLSupport.Tests.Data.Classes;
 using Xunit;
 

--- a/AdvancedDLSupport/ImplementationGenerators/Terminating/DelegateMethodImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Terminating/DelegateMethodImplementationGenerator.cs
@@ -19,11 +19,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.InteropServices;
-using System.Security;
 using AdvancedDLSupport.Extensions;
 using AdvancedDLSupport.Pipeline;
 using AdvancedDLSupport.Reflection;
@@ -34,9 +31,6 @@ using StrictEmit;
 using static AdvancedDLSupport.ImplementationGenerators.GeneratorComplexity;
 
 using static AdvancedDLSupport.ImplementationOptions;
-using static System.Reflection.CallingConventions;
-using static System.Reflection.MethodAttributes;
-using static System.Reflection.MethodImplAttributes;
 
 namespace AdvancedDLSupport.ImplementationGenerators
 {

--- a/AdvancedDLSupport/Loaders/IPlatformLoader.cs
+++ b/AdvancedDLSupport/Loaders/IPlatformLoader.cs
@@ -39,13 +39,14 @@ namespace AdvancedDLSupport.Loaders
         T LoadFunction<T>(IntPtr library, [NotNull] string symbolName);
 
         /// <summary>
-        /// Load the given library.
+        /// Load the given library. A null path signifies intent to load the main executable instead of an external
+        /// library.
         /// </summary>
         /// <param name="path">The path to the library.</param>
         /// <returns>A handle to the library. This value carries no intrinsic meaning.</returns>
         /// <exception cref="LibraryLoadingException">Thrown if the library could not be loaded.</exception>
         [PublicAPI]
-        IntPtr LoadLibrary([NotNull] string path);
+        IntPtr LoadLibrary([CanBeNull] string path);
 
         /// <summary>
         /// Load the given symbol.

--- a/AdvancedDLSupport/NativeLibraryBase.cs
+++ b/AdvancedDLSupport/NativeLibraryBase.cs
@@ -69,7 +69,7 @@ namespace AdvancedDLSupport
         [PublicAPI, AnonymousConstructor]
         protected NativeLibraryBase
         (
-            [NotNull] string path,
+            [CanBeNull] string path,
             ImplementationOptions options
         )
         {

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -544,7 +544,7 @@ namespace AdvancedDLSupport
         private object CreateAnonymousImplementationInstance
         (
             [NotNull] Type finalType,
-            [NotNull] string library,
+            [CanBeNull] string library,
             ImplementationOptions options
         )
         {

--- a/AdvancedDLSupport/PathResolvers/DynamicLinkLibraryPathResolver.cs
+++ b/AdvancedDLSupport/PathResolvers/DynamicLinkLibraryPathResolver.cs
@@ -150,9 +150,9 @@ namespace AdvancedDLSupport
                 }
             }
 
-            if (!(Type.GetType("Mono.Runtime") is null) && library == "__Internal")
+            if (library == "__Internal")
             {
-                // Mono extension: Search the main program
+                // Mono extension: Search the main program. Allowed for all runtimes
                 return ResolvePathResult.FromSuccess(null);
             }
 


### PR DESCRIPTION
### Purpose of this PR

This PR removes the restriction on the special library name `__Internal` that lets users load symbols from the main executable, allowing any runtime to use it..