### PR TITLE
Fix attribute inheritance in mixed-mode classes.

### DIFF
--- a/AdvancedDLSupport.AOT.Tests/AdvancedDLSupport.AOT.Tests.csproj
+++ b/AdvancedDLSupport.AOT.Tests/AdvancedDLSupport.AOT.Tests.csproj
@@ -9,10 +9,10 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/AdvancedDLSupport.Tests/AdvancedDLSupport.Tests.csproj
+++ b/AdvancedDLSupport.Tests/AdvancedDLSupport.Tests.csproj
@@ -13,10 +13,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithNativeSymbolInClass.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithNativeSymbolInClass.cs
@@ -1,0 +1,38 @@
+﻿//
+//  MixedModeClassWithNativeSymbolInClass.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+
+#pragma warning disable SA1600, CS1591
+
+// ReSharper disable ValueParameterNotUsed
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+    public abstract class MixedModeClassWithNativeSymbolInClass
+        : NativeLibraryBase, IMixedModeLibraryWithNativeSymbolInClass
+    {
+        public MixedModeClassWithNativeSymbolInClass(string path, Type interfaceType, ImplementationOptions options)
+            : base(path, options)
+        {
+        }
+
+        [NativeSymbol(Entrypoint = "sym_Subtract")]
+        public abstract int SubtractWithRemappedName(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithNativeSymbolInInterface.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithNativeSymbolInInterface.cs
@@ -1,0 +1,37 @@
+﻿//
+//  MixedModeClassWithNativeSymbolInInterface.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+
+#pragma warning disable SA1600, CS1591
+
+// ReSharper disable ValueParameterNotUsed
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+    public abstract class MixedModeClassWithNativeSymbolInInterface
+        : NativeLibraryBase, IMixedModeLibraryWithNativeSymbolInInterface
+    {
+        public MixedModeClassWithNativeSymbolInInterface(string path, Type interfaceType, ImplementationOptions options)
+            : base(path, options)
+        {
+        }
+
+        public abstract int SubtractWithRemappedName(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithNativeSymbolInInterfaceAndClass.cs
+++ b/AdvancedDLSupport.Tests/Data/Classes/MixedModeClassWithNativeSymbolInInterfaceAndClass.cs
@@ -1,0 +1,38 @@
+﻿//
+//  MixedModeClassWithNativeSymbolInInterfaceAndClass.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+
+#pragma warning disable SA1600, CS1591
+
+// ReSharper disable ValueParameterNotUsed
+namespace AdvancedDLSupport.Tests.Data.Classes
+{
+    public abstract class MixedModeClassWithNativeSymbolInInterfaceAndClass
+        : NativeLibraryBase, IMixedModeLibraryWithIncorrectNativeSymbolInInterface
+    {
+        public MixedModeClassWithNativeSymbolInInterfaceAndClass(string path, Type interfaceType, ImplementationOptions options)
+            : base(path, options)
+        {
+        }
+
+        [NativeSymbol(Entrypoint = "sym_Subtract")]
+        public abstract int SubtractWithRemappedName(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryWithIncorrectNativeSymbolInInterface.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryWithIncorrectNativeSymbolInInterface.cs
@@ -1,0 +1,29 @@
+﻿//
+//  IMixedModeLibraryWithIncorrectNativeSymbolInInterface.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IMixedModeLibraryWithIncorrectNativeSymbolInInterface
+    {
+        [NativeSymbol(Entrypoint = "BADSYMBOL")]
+        int SubtractWithRemappedName(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryWithNativeSymbolInClass.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryWithNativeSymbolInClass.cs
@@ -1,0 +1,28 @@
+﻿//
+//  IMixedModeLibraryWithNativeSymbolInClass.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IMixedModeLibraryWithNativeSymbolInClass
+    {
+        int SubtractWithRemappedName(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryWithNativeSymbolInInterface.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IMixedModeLibraryWithNativeSymbolInInterface.cs
@@ -1,0 +1,29 @@
+﻿//
+//  IMixedModeLibraryWithNativeSymbolInInterface.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IMixedModeLibraryWithNativeSymbolInInterface
+    {
+        [NativeSymbol(Entrypoint = "sym_Subtract")]
+        int SubtractWithRemappedName(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
@@ -57,6 +57,13 @@ namespace AdvancedDLSupport.Tests.Integration
         }
 
         [Fact]
+        public void CanActivateClassWithNativeSymbolInInterface()
+        {
+            var library = _builder.ActivateClass<MixedModeClassWithNativeSymbolInInterface>(LibraryName);
+            Assert.Equal(5, library.SubtractWithRemappedName(10, 5));
+        }
+
+        [Fact]
         public void CanActivateClassWithInheritedNativeInterfaces()
         {
             _builder.ActivateClass<MixedModeClassWithInheritedInterface>(LibraryName);

--- a/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/MixedModeTests.cs
@@ -64,6 +64,20 @@ namespace AdvancedDLSupport.Tests.Integration
         }
 
         [Fact]
+        public void CanActivateClassWithNativeSymbolInClass()
+        {
+            var library = _builder.ActivateClass<MixedModeClassWithNativeSymbolInClass>(LibraryName);
+            Assert.Equal(5, library.SubtractWithRemappedName(10, 5));
+        }
+
+        [Fact]
+        public void CanActivateClassWithNativeSymbolInBothInterfaceAndClass()
+        {
+            var library = _builder.ActivateClass<MixedModeClassWithNativeSymbolInInterfaceAndClass>(LibraryName);
+            Assert.Equal(5, library.SubtractWithRemappedName(10, 5));
+        }
+
+        [Fact]
         public void CanActivateClassWithInheritedNativeInterfaces()
         {
             _builder.ActivateClass<MixedModeClassWithInheritedInterface>(LibraryName);

--- a/AdvancedDLSupport.Tests/c/src/MixedModeTests.c
+++ b/AdvancedDLSupport.Tests/c/src/MixedModeTests.c
@@ -18,3 +18,8 @@ __declspec(dllexport) int32_t Subtract(int value, int other)
 {
     return value - other;
 }
+
+__declspec(dllexport) int32_t sym_Subtract(int value, int other)
+{
+    return value - other;
+}

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -605,11 +605,9 @@ namespace AdvancedDLSupport
                         {
                             continue;
                         }
-
-                        targetMethod = baseClassMethod;
                     }
 
-                    var definition = pipeline.GenerateDefinitionFromSignature(targetMethod);
+                    var definition = pipeline.GenerateDefinitionFromSignature(targetMethod, baseClassMethod);
                     methods.Add
                     (
                         new PipelineWorkUnit<IntrospectiveMethodInfo>

--- a/AdvancedDLSupport/Reflection/IntrospectiveMemberBase.cs
+++ b/AdvancedDLSupport/Reflection/IntrospectiveMemberBase.cs
@@ -75,7 +75,7 @@ namespace AdvancedDLSupport.Reflection
             MemberType = memberInfo.MemberType;
             ReflectedType = memberInfo.ReflectedType;
 
-            CustomAttributes = memberInfo.CustomAttributes;
+            CustomAttributes = memberInfo.CustomAttributes.ToList();
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace AdvancedDLSupport.Reflection
             MemberType = memberInfo.MemberType;
             ReflectedType = memberInfo.ReflectedType;
 
-            CustomAttributes = customAttributes ?? new List<CustomAttributeData>();
+            CustomAttributes = customAttributes?.ToList() ?? new List<CustomAttributeData>();
         }
 
         /// <summary>

--- a/AdvancedDLSupport/Utility/GeneratedImplementationTypeIdentifier.cs
+++ b/AdvancedDLSupport/Utility/GeneratedImplementationTypeIdentifier.cs
@@ -88,9 +88,23 @@ namespace AdvancedDLSupport
             unchecked
             {
                 return
-                    ((BaseClassType != null ? BaseClassType.GetHashCode() : 0) * 397) ^
-                    ((InterfaceTypes != null ? InterfaceTypes.Aggregate(17, (result, interfaceType) => (result * 23) + interfaceType.GetHashCode()) : 0) * 397) ^
-                    ((int)Options * 397);
+                    (
+                        (BaseClassType != null ? BaseClassType.GetHashCode() : 0) * 397
+                    ) ^
+                    (
+                        (
+                            InterfaceTypes != null
+                            ? InterfaceTypes.Aggregate
+                            (
+                                17,
+                                (result, interfaceType) => (result * 23) + interfaceType.GetHashCode()
+                            )
+                            : 0
+                        ) * 397
+                    ) ^
+                    (
+                        (int)Options * 397
+                    );
             }
         }
     }

--- a/Mono.DllMap.Tests/Mono.DllMap.Tests.csproj
+++ b/Mono.DllMap.Tests/Mono.DllMap.Tests.csproj
@@ -29,10 +29,10 @@
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta006" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/interface-composition.md
+++ b/docs/interface-composition.md
@@ -26,3 +26,10 @@ var errorMessage = thingDoer.GetErrorString(result);
 ```
 
 This type of inheritance is supported to an arbitrary inheritance depth and composition.
+
+Something to be aware of is that C# does not normally transfer attributes applied in an interface to the implementing 
+class. ADL does its own transfer of attributes from the interface to the class, and as such, you can apply attributes in
+the interface and still have them affect a mixed-mode class. 
+
+This does come with a gotcha - if the implementation in the mixed-mode class has *any* attributes at all, those 
+attributes will take precedence over the ones in the interface (which will be ignored).


### PR DESCRIPTION
### Purpose of this PR

This PR fixes some unintuitive behaviour with attributes and mixed-mode classes. Previously, attributes would not be transferred over to the mixed-mode class, and would only apply to the interface. This forced developers to reapply any attributes in their mixed-mode classes.

Attributes are now transferred properly, however, since this is not how C# normally does things, there are some caveats. Primarily, it boils down to the following set of rules:

1. If an interface and a mixed-mode class both apply attributes to a member, the mixed-mode class's attributes take precedence, and the interface's attributes are ignored.
2. If an interface applies attributes to a member, but a mixed-mode class does not, the interface's attributes are used.

Fixes #52.
