### PR TITLE
Ensure duplicated interface members are explicitly overridden

### DIFF
--- a/AdvancedDLSupport.Tests/AdvancedDLSupport.Tests.csproj
+++ b/AdvancedDLSupport.Tests/AdvancedDLSupport.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="all" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithCombinedIdenticalSignatures.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithCombinedIdenticalSignatures.cs
@@ -1,0 +1,30 @@
+//
+//  IInterfaceWithCombinedIdenticalSignatures.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.InteropServices;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IInterfaceWithCombinedIdenticalSignatures
+        : IInterfaceWithFirstIdenticalSignature, IInterfaceWithSecondIdenticalSignature
+    {
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithCombinedIdenticalSignaturesWithDifferentEntrypoints.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithCombinedIdenticalSignaturesWithDifferentEntrypoints.cs
@@ -1,0 +1,31 @@
+//
+//  IInterfaceWithCombinedIdenticalSignaturesWithDifferentEntrypoints.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.InteropServices;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IInterfaceWithCombinedIdenticalSignaturesWithDifferentEntrypoints
+        : IInterfaceWithFirstIdenticalSignatureWithDifferentEntrypoint,
+          IInterfaceWithSecondIdenticalSignatureWithDifferentEntrypoint
+    {
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithFirstIdenticalSignature.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithFirstIdenticalSignature.cs
@@ -1,0 +1,30 @@
+//
+//  IInterfaceWithFirstIdenticalSignature.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.InteropServices;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IInterfaceWithFirstIdenticalSignature
+    {
+        int Multiply(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithFirstIdenticalSignatureWithDifferentEntrypoint.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithFirstIdenticalSignatureWithDifferentEntrypoint.cs
@@ -1,0 +1,31 @@
+//
+//  IInterfaceWithFirstIdenticalSignatureWithDifferentEntrypoint.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.InteropServices;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IInterfaceWithFirstIdenticalSignatureWithDifferentEntrypoint
+    {
+        [NativeSymbol("Multiply")]
+        int DoMath(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithSecondIdenticalSignature.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithSecondIdenticalSignature.cs
@@ -1,0 +1,30 @@
+//
+//  IInterfaceWithSecondIdenticalSignature.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.InteropServices;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IInterfaceWithSecondIdenticalSignature
+    {
+        int Multiply(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithSecondIdenticalSignatureWithDifferentEntrypoint.cs
+++ b/AdvancedDLSupport.Tests/Data/Interfaces/IInterfaceWithSecondIdenticalSignatureWithDifferentEntrypoint.cs
@@ -1,0 +1,31 @@
+//
+//  IInterfaceWithSecondIdenticalSignatureWithDifferentEntrypoint.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System.Runtime.InteropServices;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Data
+{
+    public interface IInterfaceWithSecondIdenticalSignatureWithDifferentEntrypoint
+    {
+        [NativeSymbol("Subtract")]
+        int DoMath(int a, int b);
+    }
+}

--- a/AdvancedDLSupport.Tests/TestBases/LibraryTestBase.cs
+++ b/AdvancedDLSupport.Tests/TestBases/LibraryTestBase.cs
@@ -19,6 +19,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 
 #pragma warning disable SA1600, CS1591
 
@@ -28,10 +29,11 @@ namespace AdvancedDLSupport.Tests.TestBases
     {
         protected ImplementationOptions Config { get; }
 
+        [NotNull]
         protected T Library { get; }
 
         [SuppressMessage("ReSharper", "VirtualMemberCallInConstructor", Justification = "Used to set implementation options in derived classes")]
-        public LibraryTestBase(string libraryLocation)
+        public LibraryTestBase([NotNull] string libraryLocation)
         {
             Config = GetImplementationOptions();
             Library = GetImplementationBuilder().ActivateInterface<T>(libraryLocation);
@@ -42,6 +44,7 @@ namespace AdvancedDLSupport.Tests.TestBases
             return ImplementationOptions.GenerateDisposalChecks;
         }
 
+        [NotNull]
         protected virtual NativeLibraryBuilder GetImplementationBuilder()
         {
             return new NativeLibraryBuilder(Config);

--- a/AdvancedDLSupport.Tests/Tests/Integration/InheritedInterfaceTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/InheritedInterfaceTests.cs
@@ -1,0 +1,64 @@
+//
+//  InheritedInterfaceTests.cs
+//
+//  Copyright (c) 2018 Firwood Software
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+using System;
+using AdvancedDLSupport.Tests.Data;
+using AdvancedDLSupport.Tests.TestBases;
+using Xunit;
+
+#pragma warning disable SA1600, CS1591
+
+namespace AdvancedDLSupport.Tests.Integration
+{
+    public class InheritedInterfaceTests : LibraryTestBase<IInterfaceWithCombinedIdenticalSignatures>
+    {
+        private const string LibraryName = "FunctionTests";
+
+        public InheritedInterfaceTests()
+            : base(LibraryName)
+        {
+        }
+
+        [Fact]
+        public void CanCallMethodInFirstInterface()
+        {
+            const int a = 5;
+            const int b = 20;
+
+            const int expected = a * b;
+
+            var result = ((IInterfaceWithFirstIdenticalSignature)Library).Multiply(a, b);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void CanCallMethodInSecondInterface()
+        {
+            const int a = 5;
+            const int b = 30;
+
+            const int expected = a * b;
+
+            var result = ((IInterfaceWithSecondIdenticalSignature)Library).Multiply(a, b);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/AdvancedDLSupport.Tests/Tests/Integration/InheritedInterfaceTests.cs
+++ b/AdvancedDLSupport.Tests/Tests/Integration/InheritedInterfaceTests.cs
@@ -26,39 +26,79 @@ using Xunit;
 
 namespace AdvancedDLSupport.Tests.Integration
 {
-    public class InheritedInterfaceTests : LibraryTestBase<IInterfaceWithCombinedIdenticalSignatures>
+    public class InheritedInterfaceTests
     {
-        private const string LibraryName = "FunctionTests";
-
-        public InheritedInterfaceTests()
-            : base(LibraryName)
+        public class IdenticalInheritedInterfaceTests : LibraryTestBase<IInterfaceWithCombinedIdenticalSignatures>
         {
+            private const string LibraryName = "FunctionTests";
+
+            public IdenticalInheritedInterfaceTests()
+                : base(LibraryName)
+            {
+            }
+
+            [Fact]
+            public void CanCallIdenticalMethodInFirstInterface()
+            {
+                const int a = 5;
+                const int b = 20;
+
+                const int expected = a * b;
+
+                var result = ((IInterfaceWithFirstIdenticalSignature)Library).Multiply(a, b);
+
+                Assert.Equal(expected, result);
+            }
+
+            [Fact]
+            public void CanCallIdenticalMethodInSecondInterface()
+            {
+                const int a = 5;
+                const int b = 30;
+
+                const int expected = a * b;
+
+                var result = ((IInterfaceWithSecondIdenticalSignature)Library).Multiply(a, b);
+
+                Assert.Equal(expected, result);
+            }
         }
 
-        [Fact]
-        public void CanCallMethodInFirstInterface()
+        public class DifferentEntrypointInheritedInterfaceTests
+            : LibraryTestBase<IInterfaceWithCombinedIdenticalSignaturesWithDifferentEntrypoints>
         {
-            const int a = 5;
-            const int b = 20;
+            private const string LibraryName = "FunctionTests";
 
-            const int expected = a * b;
+            public DifferentEntrypointInheritedInterfaceTests()
+                : base(LibraryName)
+            {
+            }
 
-            var result = ((IInterfaceWithFirstIdenticalSignature)Library).Multiply(a, b);
+            [Fact]
+            public void CanCallMethodWithSameSignatureButDifferentEntrypointInFirstInterface()
+            {
+                const int a = 5;
+                const int b = 20;
 
-            Assert.Equal(expected, result);
-        }
+                const int expected = a * b;
 
-        [Fact]
-        public void CanCallMethodInSecondInterface()
-        {
-            const int a = 5;
-            const int b = 30;
+                var result = ((IInterfaceWithFirstIdenticalSignatureWithDifferentEntrypoint)Library).DoMath(a, b);
 
-            const int expected = a * b;
+                Assert.Equal(expected, result);
+            }
 
-            var result = ((IInterfaceWithSecondIdenticalSignature)Library).Multiply(a, b);
+            [Fact]
+            public void CanCallMethodWithSameSignatureButDifferentEntrypointInSecondInterface()
+            {
+                const int a = 5;
+                const int b = 30;
 
-            Assert.Equal(expected, result);
+                const int expected = a - b;
+
+                var result = ((IInterfaceWithSecondIdenticalSignatureWithDifferentEntrypoint)Library).DoMath(a, b);
+
+                Assert.Equal(expected, result);
+            }
         }
     }
 }

--- a/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
+++ b/AdvancedDLSupport/AdvancedDLSupport.ExternalAnnotations.xml
@@ -357,6 +357,7 @@
   </member>
   <member name="P:AdvancedDLSupport.ManglerRepository.Default">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:AdvancedDLSupport.ManglerRepository.GetApplicableManglers``1(``0)">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
@@ -535,18 +536,42 @@
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
   </member>
+  <member name="M:AdvancedDLSupport.Reflection.IIntrospectiveMember.GetFullNativeEntrypoint">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="M:AdvancedDLSupport.Reflection.IIntrospectiveMember.GetNativeCallingConvention">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+  </member>
+  <member name="M:AdvancedDLSupport.Reflection.IIntrospectiveMember.GetNativeEntrypoint">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="P:AdvancedDLSupport.Reflection.IIntrospectiveMember.Name">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
   <member name="T:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>
-  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.#ctor(`0)">
+  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.#ctor(`0,System.Type)">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <parameter name="memberInfo">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
+    <parameter name="metadataType">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
   </member>
-  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.#ctor(`0,System.Collections.Generic.IEnumerable{System.Reflection.CustomAttributeData})">
+  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.#ctor(`0,System.Type,System.Collections.Generic.IEnumerable{System.Reflection.CustomAttributeData})">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <parameter name="memberInfo">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+    <parameter name="metadataType">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="customAttributes">
@@ -559,6 +584,7 @@
   </member>
   <member name="P:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.DeclaringType">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.GetCustomAttribute``1">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
@@ -572,6 +598,13 @@
   <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.GetWrappedMember">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>
+  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.HasSameNativeEntrypointAs(AdvancedDLSupport.Reflection.IntrospectiveMethodInfo)">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
+    <parameter name="other">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+  </member>
   <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.IsDefined(System.Type,System.Boolean)">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>
@@ -580,6 +613,9 @@
   </member>
   <member name="P:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.MemberType">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+  </member>
+  <member name="P:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.MetadataType">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="P:AdvancedDLSupport.Reflection.IntrospectiveMemberBase`1.Name">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
@@ -596,7 +632,7 @@
   <member name="T:AdvancedDLSupport.Reflection.IntrospectiveMethodInfo">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>
-  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMethodInfo.#ctor(System.Reflection.Emit.MethodBuilder,System.Type,System.Collections.Generic.IEnumerable{System.Type},AdvancedDLSupport.Reflection.IntrospectiveMethodInfo)">
+  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMethodInfo.#ctor(System.Reflection.Emit.MethodBuilder,System.Type,System.Collections.Generic.IEnumerable{System.Type},System.Type,AdvancedDLSupport.Reflection.IntrospectiveMethodInfo)">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <parameter name="builder">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -608,13 +644,19 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
       <attribute ctor="M:JetBrains.Annotations.ItemNotNullAttribute.#ctor" />
     </parameter>
+    <parameter name="metadataType">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
     <parameter name="definitionToCopyAttributesFrom">
       <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
-  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMethodInfo.#ctor(System.Reflection.MethodInfo)">
+  <member name="M:AdvancedDLSupport.Reflection.IntrospectiveMethodInfo.#ctor(System.Reflection.MethodInfo,System.Type)">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <parameter name="methodInfo">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+    <parameter name="metadataType">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
@@ -656,9 +698,12 @@
   <member name="T:AdvancedDLSupport.Reflection.IntrospectivePropertyInfo">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>
-  <member name="M:AdvancedDLSupport.Reflection.IntrospectivePropertyInfo.#ctor(System.Reflection.PropertyInfo)">
+  <member name="M:AdvancedDLSupport.Reflection.IntrospectivePropertyInfo.#ctor(System.Reflection.PropertyInfo,System.Type)">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
     <parameter name="memberInfo">
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    </parameter>
+    <parameter name="metadataType">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
@@ -759,7 +804,17 @@
   <member name="P:AdvancedDLSupport.SymbolLoadingException.SymbolName">
     <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
   </member>
+  <member name="T:AdvancedDLSupport.SymbolTransformer">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+  </member>
+  <member name="F:AdvancedDLSupport.SymbolTransformer.Default">
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+  </member>
   <member name="M:AdvancedDLSupport.SymbolTransformer.GetTransformedSymbol``1(System.Type,``0)">
+    <attribute ctor="M:JetBrains.Annotations.PublicAPIAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.PureAttribute.#ctor" />
     <parameter name="containingInterface">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>

--- a/AdvancedDLSupport/AdvancedDLSupport.csproj
+++ b/AdvancedDLSupport/AdvancedDLSupport.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <Title>AdvancedDLSupport</Title>
-    <Version>2.3.2-rc1</Version>
+    <Version>2.3.2-rc3</Version>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>AdvancedDLSupport</PackageId>

--- a/AdvancedDLSupport/Extensions/ModuleBuilderExtensions.cs
+++ b/AdvancedDLSupport/Extensions/ModuleBuilderExtensions.cs
@@ -51,14 +51,11 @@ namespace AdvancedDLSupport.Extensions
             bool suppressSecurity = false
         )
         {
-            var metadataAttribute = baseMember.GetCustomAttribute<NativeSymbolAttribute>() ??
-                                    new NativeSymbolAttribute(baseMember.Name);
-
             var delegateBuilder = DefineDelegateType
             (
                 module,
                 name,
-                metadataAttribute.CallingConvention,
+                baseMember.GetNativeCallingConvention(),
                 suppressSecurity
             );
 

--- a/AdvancedDLSupport/Extensions/TypeExtensions.cs
+++ b/AdvancedDLSupport/Extensions/TypeExtensions.cs
@@ -119,7 +119,7 @@ namespace AdvancedDLSupport.Extensions
             var methods = @this.GetMethods(bindingFlags);
             foreach (var method in methods)
             {
-                yield return new IntrospectiveMethodInfo(method);
+                yield return new IntrospectiveMethodInfo(method, @this);
             }
 
             if (!@this.IsInterface || !flattenHierarchy)
@@ -132,7 +132,7 @@ namespace AdvancedDLSupport.Extensions
                 var interfaceMethods = inf.GetMethods(bindingFlags);
                 foreach (var method in interfaceMethods)
                 {
-                    yield return new IntrospectiveMethodInfo(method);
+                    yield return new IntrospectiveMethodInfo(method, @this);
                 }
             }
         }
@@ -153,7 +153,7 @@ namespace AdvancedDLSupport.Extensions
         )
         {
             var method = @this.GetMethod(name, parameterTypes);
-            return method is null ? null : new IntrospectiveMethodInfo(method);
+            return method is null ? null : new IntrospectiveMethodInfo(method, @this);
         }
 
         /// <summary>

--- a/AdvancedDLSupport/ImplementationGenerators/Multiplying/RefPermutationImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Multiplying/RefPermutationImplementationGenerator.cs
@@ -91,7 +91,7 @@ namespace AdvancedDLSupport.ImplementationGenerators
                     permutation.ToArray()
                 );
 
-                var methodInfo = new IntrospectiveMethodInfo(method, definition.ReturnType, permutation, definition);
+                var methodInfo = new IntrospectiveMethodInfo(method, definition.ReturnType, permutation, definition.MetadataType, definition);
                 permutations.Add(methodInfo);
             }
 

--- a/AdvancedDLSupport/ImplementationGenerators/Terminating/IndirectCallMethodImplementationGenerator.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Terminating/IndirectCallMethodImplementationGenerator.cs
@@ -81,9 +81,6 @@ namespace AdvancedDLSupport.ImplementationGenerators
         {
             var definition = workUnit.Definition;
 
-            var metadataAttribute = definition.GetCustomAttribute<NativeSymbolAttribute>() ??
-                                    new NativeSymbolAttribute(definition.Name);
-
             var backingFieldType = typeof(IntPtr);
 
             var backingField = Options.HasFlagFast(UseLazyBinding)
@@ -101,7 +98,7 @@ namespace AdvancedDLSupport.ImplementationGenerators
             );
 
             AugmentHostingTypeConstructorWithNativeInitialization(workUnit.SymbolName, backingFieldType, backingField);
-            GenerateNativeInvokerBody(definition, metadataAttribute.CallingConvention, backingField);
+            GenerateNativeInvokerBody(definition, definition.GetNativeCallingConvention(), backingField);
 
             yield break;
         }

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/BooleanMarshallingWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/BooleanMarshallingWrapper.cs
@@ -147,7 +147,14 @@ namespace AdvancedDLSupport.ImplementationGenerators
 
             passthroughMethod.ApplyCustomAttributesFrom(definition, newReturnType, newParameterTypes);
 
-            return new IntrospectiveMethodInfo(passthroughMethod, newReturnType, newParameterTypes, definition);
+            return new IntrospectiveMethodInfo
+            (
+                passthroughMethod,
+                newReturnType,
+                newParameterTypes,
+                definition.MetadataType,
+                definition
+            );
         }
 
         /// <summary>

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/CallWrapperBase.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/CallWrapperBase.cs
@@ -117,7 +117,14 @@ namespace AdvancedDLSupport.ImplementationGenerators
 
             passthroughMethod.ApplyCustomAttributesFrom(workUnit.Definition);
 
-            return new IntrospectiveMethodInfo(passthroughMethod, definition.ReturnType, definition.ParameterTypes, definition);
+            return new IntrospectiveMethodInfo
+            (
+                passthroughMethod,
+                definition.ReturnType,
+                definition.ParameterTypes,
+                definition.MetadataType,
+                definition
+            );
         }
 
         /// <inheritdoc />

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/GenericDelegateWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/GenericDelegateWrapper.cs
@@ -235,7 +235,14 @@ namespace AdvancedDLSupport.ImplementationGenerators
 
             passthroughMethod.ApplyCustomAttributesFrom(definition, newReturnType, newParameterTypes);
 
-            return new IntrospectiveMethodInfo(passthroughMethod, newReturnType, newParameterTypes, definition);
+            return new IntrospectiveMethodInfo
+            (
+                passthroughMethod,
+                newReturnType,
+                newParameterTypes,
+                definition.MetadataType,
+                definition
+            );
         }
 
         /// <summary>

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/StringMarshallingWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/StringMarshallingWrapper.cs
@@ -307,7 +307,14 @@ namespace AdvancedDLSupport.ImplementationGenerators
                 newParameterTypes
             );
 
-            return new IntrospectiveMethodInfo(passthroughMethod, newReturnType, newParameterTypes, definition);
+            return new IntrospectiveMethodInfo
+            (
+                passthroughMethod,
+                newReturnType,
+                newParameterTypes,
+                definition.MetadataType,
+                definition
+            );
         }
 
         /// <summary>

--- a/AdvancedDLSupport/ImplementationGenerators/Wrappers/ValueNullableMarshallingWrapper.cs
+++ b/AdvancedDLSupport/ImplementationGenerators/Wrappers/ValueNullableMarshallingWrapper.cs
@@ -315,7 +315,14 @@ namespace AdvancedDLSupport.ImplementationGenerators
                 newParameterTypes
             );
 
-            return new IntrospectiveMethodInfo(passthroughMethod, newReturnType, newParameterTypes, definition);
+            return new IntrospectiveMethodInfo
+            (
+                passthroughMethod,
+                newReturnType,
+                newParameterTypes,
+                definition.MetadataType,
+                definition
+            );
         }
 
         /// <summary>

--- a/AdvancedDLSupport/Manglers/ManglerRepository.cs
+++ b/AdvancedDLSupport/Manglers/ManglerRepository.cs
@@ -36,9 +36,10 @@ namespace AdvancedDLSupport
         /// Gets the default instance of the <see cref="ManglerRepository"/> class. This instance contains all discovered
         /// mangler types.
         /// </summary>
-        [PublicAPI]
+        [PublicAPI, NotNull]
         public static ManglerRepository Default { get; }
 
+        [NotNull, ItemNotNull]
         private List<IEntrypointMangler> Manglers { get; }
 
         /// <summary>

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -590,10 +590,16 @@ namespace AdvancedDLSupport
                     var existingMethod = constructedMethods.FirstOrDefault(m => m.HasSameSignatureAs(method));
                     if (!(existingMethod is null))
                     {
-                        var duplicateDefinition = targetMethod.GetWrappedMember();
-                        pipeline.TargetType.DefineMethodOverride(existingMethod.GetWrappedMember(), duplicateDefinition);
+                        if (existingMethod.HasSameNativeEntrypointAs(targetMethod))
+                        {
+                            pipeline.TargetType.DefineMethodOverride
+                            (
+                                existingMethod.GetWrappedMember(),
+                                targetMethod.GetWrappedMember()
+                            );
 
-                        continue;
+                            continue;
+                        }
                     }
 
                     // Skip methods with a managed implementation in the base class
@@ -611,7 +617,23 @@ namespace AdvancedDLSupport
                         }
                     }
 
-                    var definition = pipeline.GenerateDefinitionFromSignature(targetMethod, baseClassMethod);
+                    // If we have an existing method at this point, this new method must be created as an explicit
+                    // interface implementation. Therefore, we override the method name.
+                    IntrospectiveMethodInfo definition;
+                    if (!(existingMethod is null))
+                    {
+                        definition = pipeline.GenerateDefinitionFromSignature
+                        (
+                            targetMethod,
+                            baseClassMethod,
+                            $"{interfaceType.Name}.{targetMethod.Name}"
+                        );
+                    }
+                    else
+                    {
+                        definition = pipeline.GenerateDefinitionFromSignature(targetMethod, baseClassMethod);
+                    }
+
                     methods.Add
                     (
                         new PipelineWorkUnit<IntrospectiveMethodInfo>
@@ -651,7 +673,7 @@ namespace AdvancedDLSupport
             var properties = new List<PipelineWorkUnit<IntrospectivePropertyInfo>>();
             foreach (var interfaceType in interfaceTypes)
             {
-                foreach (var property in interfaceType.GetProperties().Select(p => new IntrospectivePropertyInfo(p)))
+                foreach (var property in interfaceType.GetProperties().Select(p => new IntrospectivePropertyInfo(p, interfaceType)))
                 {
                     var targetProperty = property;
 
@@ -685,7 +707,7 @@ namespace AdvancedDLSupport
                             );
                         }
 
-                        targetProperty = new IntrospectivePropertyInfo(baseClassProperty);
+                        targetProperty = new IntrospectivePropertyInfo(baseClassProperty, interfaceType);
                     }
 
                     properties.Add

--- a/AdvancedDLSupport/NativeLibraryBuilder.cs
+++ b/AdvancedDLSupport/NativeLibraryBuilder.cs
@@ -587,8 +587,12 @@ namespace AdvancedDLSupport
 
                     // Skip methods that were already constructed - happens with inherited interfaces and multiple
                     // identical definitions
-                    if (constructedMethods.Any(m => m.HasSameSignatureAs(method)))
+                    var existingMethod = constructedMethods.FirstOrDefault(m => m.HasSameSignatureAs(method));
+                    if (!(existingMethod is null))
                     {
+                        var duplicateDefinition = targetMethod.GetWrappedMember();
+                        pipeline.TargetType.DefineMethodOverride(existingMethod.GetWrappedMember(), duplicateDefinition);
+
                         continue;
                     }
 
@@ -618,7 +622,7 @@ namespace AdvancedDLSupport
                         )
                     );
 
-                    constructedMethods.Add(targetMethod);
+                    constructedMethods.Add(definition);
                 }
             }
 

--- a/AdvancedDLSupport/Pipeline/ImplementationPipeline.cs
+++ b/AdvancedDLSupport/Pipeline/ImplementationPipeline.cs
@@ -192,17 +192,21 @@ namespace AdvancedDLSupport.Pipeline
         /// </summary>
         /// <param name="interfaceDefinition">The interface definition to base it on.</param>
         /// <param name="abstractImplementation">The abstract implementation, if any.</param>
+        /// <param name="nameOverride">
+        /// The name to use for the method. If null, the interface member name is used.
+        /// </param>
         /// <returns>An introspective method info for the definition.</returns>
         [NotNull]
         internal IntrospectiveMethodInfo GenerateDefinitionFromSignature
         (
             [NotNull] IntrospectiveMethodInfo interfaceDefinition,
-            [CanBeNull] IntrospectiveMethodInfo abstractImplementation
+            [CanBeNull] IntrospectiveMethodInfo abstractImplementation,
+            [CanBeNull] string nameOverride = null
         )
         {
             var methodBuilder = TargetType.DefineMethod
             (
-                interfaceDefinition.Name,
+                nameOverride ?? interfaceDefinition.Name,
                 Public | Final | Virtual | HideBySig | NewSlot,
                 CallingConventions.Standard,
                 interfaceDefinition.ReturnType,
@@ -243,6 +247,7 @@ namespace AdvancedDLSupport.Pipeline
                 methodBuilder,
                 interfaceDefinition.ReturnType,
                 interfaceDefinition.ParameterTypes,
+                interfaceDefinition.MetadataType,
                 attributePassthroughDefinition
             );
         }

--- a/AdvancedDLSupport/Pipeline/ImplementationPipeline.cs
+++ b/AdvancedDLSupport/Pipeline/ImplementationPipeline.cs
@@ -39,9 +39,6 @@ namespace AdvancedDLSupport.Pipeline
         private readonly ModuleBuilder _targetModule;
 
         [NotNull]
-        private readonly TypeBuilder _targetType;
-
-        [NotNull]
         private readonly ILGenerator _constructorIL;
 
         private readonly ImplementationOptions _options;
@@ -49,6 +46,12 @@ namespace AdvancedDLSupport.Pipeline
 
         private IReadOnlyList<IImplementationGenerator<IntrospectiveMethodInfo>> _methodGeneratorPipeline;
         private IReadOnlyList<IImplementationGenerator<IntrospectivePropertyInfo>> _propertyGeneratorPipeline;
+
+        /// <summary>
+        /// Gets the target type of the pipeline.
+        /// </summary>
+        [NotNull]
+        internal TypeBuilder TargetType { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImplementationPipeline"/> class.
@@ -66,7 +69,7 @@ namespace AdvancedDLSupport.Pipeline
         )
         {
             _targetModule = targetModule;
-            _targetType = targetType;
+            TargetType = targetType;
             _constructorIL = constructorIL;
             _options = options;
 
@@ -96,7 +99,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new RefPermutationImplementationGenerator
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -104,7 +107,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new DelegateMethodImplementationGenerator
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -112,7 +115,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new IndirectCallMethodImplementationGenerator
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -120,7 +123,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new BooleanMarshallingWrapper
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -128,7 +131,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new DisposalCallWrapper
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -136,7 +139,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new StringMarshallingWrapper
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -144,7 +147,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new ValueNullableMarshallingWrapper
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -152,7 +155,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new GenericDelegateWrapper
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -178,7 +181,7 @@ namespace AdvancedDLSupport.Pipeline
             yield return new PropertyImplementationGenerator
             (
                 _targetModule,
-                _targetType,
+                TargetType,
                 _constructorIL,
                 _options
             );
@@ -197,7 +200,7 @@ namespace AdvancedDLSupport.Pipeline
             [CanBeNull] IntrospectiveMethodInfo abstractImplementation
         )
         {
-            var methodBuilder = _targetType.DefineMethod
+            var methodBuilder = TargetType.DefineMethod
             (
                 interfaceDefinition.Name,
                 Public | Final | Virtual | HideBySig | NewSlot,
@@ -221,12 +224,12 @@ namespace AdvancedDLSupport.Pipeline
                     methodBuilder.ApplyCustomAttributesFrom(interfaceDefinition);
                 }
 
-                _targetType.DefineMethodOverride(methodBuilder, abstractImplementation.GetWrappedMember());
+                TargetType.DefineMethodOverride(methodBuilder, abstractImplementation.GetWrappedMember());
             }
             else
             {
                 methodBuilder.ApplyCustomAttributesFrom(interfaceDefinition);
-                _targetType.DefineMethodOverride(methodBuilder, interfaceDefinition.GetWrappedMember());
+                TargetType.DefineMethodOverride(methodBuilder, interfaceDefinition.GetWrappedMember());
             }
 
             var attributePassthroughDefinition = interfaceDefinition;

--- a/AdvancedDLSupport/Reflection/IIntrospectiveMember.cs
+++ b/AdvancedDLSupport/Reflection/IIntrospectiveMember.cs
@@ -18,6 +18,7 @@
 //
 
 using System;
+using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 
 namespace AdvancedDLSupport.Reflection
@@ -31,6 +32,7 @@ namespace AdvancedDLSupport.Reflection
         /// <summary>
         /// Gets the name of the member.
         /// </summary>
+        [PublicAPI, NotNull]
         string Name { get; }
 
         /// <summary>
@@ -40,5 +42,28 @@ namespace AdvancedDLSupport.Reflection
         /// <returns>The attribute, or null.</returns>
         [PublicAPI, CanBeNull]
         TAttribute GetCustomAttribute<TAttribute>() where TAttribute : Attribute;
+
+        /// <summary>
+        /// Gets the full native entrypoint of the member. This is the configured native entrypoint, with any
+        /// transformations applied.
+        /// </summary>
+        /// <returns>The native entrypoint.</returns>
+        [PublicAPI, Pure, NotNull]
+        string GetFullNativeEntrypoint();
+
+        /// <summary>
+        /// Gets the native entrypoint of the member. This is just the configured native entrypoint, without any
+        /// transformations applied.
+        /// </summary>
+        /// <returns>The native entrypoint.</returns>
+        [PublicAPI, Pure, NotNull]
+        string GetNativeEntrypoint();
+
+        /// <summary>
+        /// Gets the native calling convention of the member.
+        /// </summary>
+        /// <returns>The calling convention.</returns>
+        [PublicAPI, Pure]
+        CallingConvention GetNativeCallingConvention();
     }
 }

--- a/AdvancedDLSupport/Reflection/IntrospectiveMethodInfo.cs
+++ b/AdvancedDLSupport/Reflection/IntrospectiveMethodInfo.cs
@@ -99,9 +99,10 @@ namespace AdvancedDLSupport.Reflection
         /// Initializes a new instance of the <see cref="IntrospectiveMethodInfo"/> class.
         /// </summary>
         /// <param name="methodInfo">The <see cref="MethodInfo"/> to wrap.</param>
+        /// <param name="metadataType">The type that the member gets native metadata from.</param>
         [PublicAPI]
-        public IntrospectiveMethodInfo([NotNull] MethodInfo methodInfo)
-            : base(methodInfo, methodInfo.CustomAttributes)
+        public IntrospectiveMethodInfo([NotNull] MethodInfo methodInfo, [NotNull] Type metadataType)
+            : base(methodInfo, metadataType, methodInfo.CustomAttributes)
         {
             if (methodInfo is MethodBuilder)
             {
@@ -188,6 +189,7 @@ namespace AdvancedDLSupport.Reflection
         /// <param name="builder">The method builder to wrap.</param>
         /// <param name="returnType">The return type of the method.</param>
         /// <param name="parameterTypes">The parameter types of the method.</param>
+        /// <param name="metadataType">The type that the member gets native metadata from.</param>
         /// <param name="definitionToCopyAttributesFrom">The definition to copy custom attributes from.</param>
         [PublicAPI]
         public IntrospectiveMethodInfo
@@ -195,8 +197,10 @@ namespace AdvancedDLSupport.Reflection
             [NotNull] MethodBuilder builder,
             [NotNull] Type returnType,
             [NotNull, ItemNotNull] IEnumerable<Type> parameterTypes,
-            [CanBeNull] IntrospectiveMethodInfo definitionToCopyAttributesFrom = null)
-            : base(builder, definitionToCopyAttributesFrom?.CustomAttributes ?? new List<CustomAttributeData>())
+            [NotNull] Type metadataType,
+            [CanBeNull] IntrospectiveMethodInfo definitionToCopyAttributesFrom = null
+        )
+            : base(builder, metadataType, definitionToCopyAttributesFrom?.CustomAttributes ?? new List<CustomAttributeData>())
         {
             ReturnType = returnType;
             ParameterTypes = parameterTypes.ToList();

--- a/AdvancedDLSupport/Reflection/IntrospectivePropertyInfo.cs
+++ b/AdvancedDLSupport/Reflection/IntrospectivePropertyInfo.cs
@@ -59,9 +59,10 @@ namespace AdvancedDLSupport.Reflection
         /// Initializes a new instance of the <see cref="IntrospectivePropertyInfo"/> class.
         /// </summary>
         /// <param name="memberInfo">The property info to wrap.</param>
+        /// <param name="metadataType">The type that the member gets native metadata from.</param>
         [PublicAPI]
-        public IntrospectivePropertyInfo([NotNull] PropertyInfo memberInfo)
-            : base(memberInfo)
+        public IntrospectivePropertyInfo([NotNull] PropertyInfo memberInfo, [NotNull] Type metadataType)
+            : base(memberInfo, metadataType)
         {
             PropertyType = memberInfo.PropertyType;
             IndexParameterTypes = memberInfo.GetIndexParameters().Select(p => p.ParameterType).ToList();

--- a/AdvancedDLSupport/SymbolTransformation/SymbolTransformer.cs
+++ b/AdvancedDLSupport/SymbolTransformation/SymbolTransformer.cs
@@ -32,11 +32,13 @@ namespace AdvancedDLSupport
     /// <summary>
     /// Transforms native symbol names based on information from a <see cref="NativeSymbolsAttribute"/>.
     /// </summary>
+    [PublicAPI]
     public class SymbolTransformer
     {
         /// <summary>
         /// Gets the default instance of the <see cref="SymbolTransformer"/> class.
         /// </summary>
+        [NotNull, PublicAPI]
         public static readonly SymbolTransformer Default = new SymbolTransformer();
 
         /// <summary>
@@ -46,13 +48,11 @@ namespace AdvancedDLSupport
         /// <param name="memberInfo">The member.</param>
         /// <typeparam name="T">The type of the member.</typeparam>
         /// <returns>The transformed symbol.</returns>
-        /// <exception cref="AmbiguousMatchException">Thrown if the member has more than on applicable name mangler.</exception>
+        /// <exception cref="AmbiguousMatchException">Thrown if the member has more than one applicable name mangler.</exception>
+        [PublicAPI, NotNull, Pure]
         public string GetTransformedSymbol<T>([NotNull] Type containingInterface, [NotNull] T memberInfo) where T : MemberInfo, IIntrospectiveMember
         {
-            var nativeSymbolAttribute = memberInfo.GetCustomAttribute<NativeSymbolAttribute>()
-                                        ?? new NativeSymbolAttribute(memberInfo.Name);
-
-            var symbolName = nativeSymbolAttribute.Entrypoint;
+            var symbolName = memberInfo.GetNativeEntrypoint();
             var applicableManglers = ManglerRepository.Default.GetApplicableManglers(memberInfo).ToList();
             if (applicableManglers.Count > 1)
             {
@@ -85,7 +85,7 @@ namespace AdvancedDLSupport
         /// <param name="prefix">The prefix to be added to the symbol. Defaults to nothing.</param>
         /// <param name="method">The transformer to apply to the symbol after concatenation.</param>
         /// <returns>The transformed symbol name.</returns>
-        [Pure]
+        [PublicAPI, NotNull, Pure]
         private string Transform
         (
             [NotNull] string symbol,


### PR DESCRIPTION
This PR fixes an issue where ambiguous interface definitions were not explicitly defined as implemented on a resulting class.

Furthermore, it implements support for multiple identical signatures with different entry points, mapping each beyond the first to an explicit interface implementation.

It is likely this was the cause of #65, but we have been unable to reproduce the problem outside of the library that first encountered it.